### PR TITLE
chore: relock dependencies

### DIFF
--- a/requirements/dev_3.9.txt
+++ b/requirements/dev_3.9.txt
@@ -10,18 +10,20 @@ attrs==21.4.0
     # via pytest
 bandit[toml]==1.7.4
     # via -r requirements/dev.in
-certifi==2022.5.18.1
+build==0.8.0
+    # via pip-tools
+certifi==2022.6.15
     # via requests
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 click==8.1.3
     # via
     #   pip-compile-multi
     #   pip-tools
     #   safety
-coverage[toml]==6.4
+coverage[toml]==6.4.1
     # via pytest-cov
 distlib==0.3.4
     # via virtualenv
@@ -57,19 +59,19 @@ mccabe==0.6.1
     # via flake8
 mpmath==1.2.1
     # via sympy
-mypy==0.960
+mypy==0.961
     # via -r requirements/dev.in
 mypy-extensions==0.4.3
     # via mypy
-networkx==2.8.2
+networkx==2.8.4
     # via
     #   -r requirements/main.in
     #   torch-geometric
-nodeenv==1.6.0
+nodeenv==1.7.0
     # via pre-commit
-numexpr==2.8.1
+numexpr==2.8.3
     # via tables
-numpy==1.22.4
+numpy==1.23.0
     # via
     #   numexpr
     #   pandas
@@ -80,22 +82,23 @@ numpy==1.22.4
     #   torch-geometric
 packaging==21.3
     # via
+    #   build
     #   dparse
     #   numexpr
     #   pytest
     #   safety
     #   tables
-pandas==1.4.2
+pandas==1.4.3
     # via torch-geometric
 pbr==5.9.0
     # via stevedore
 pep517==0.12.0
-    # via pip-tools
+    # via build
 pillow==9.1.1
     # via rdkit-pypi
 pip-compile-multi==2.4.5
     # via -r requirements/dev.in
-pip-tools==6.6.2
+pip-tools==6.8.0
     # via pip-compile-multi
 platformdirs==2.5.2
     # via virtualenv
@@ -133,13 +136,17 @@ pyyaml==6.0
     #   yacs
 rdflib==6.1.1
     # via torch-geometric
-rdkit-pypi==2022.3.2.1
+rdkit-pypi==2022.3.3
     # via -r requirements/main.in
-requests==2.27.1
+requests==2.28.1
     # via
     #   safety
     #   torch-geometric
-safety==1.10.3
+ruamel-yaml==0.17.21
+    # via safety
+ruamel-yaml-clib==0.2.6
+    # via ruamel-yaml
+safety==2.0.0
     # via -r requirements/dev.in
 scikit-learn==1.1.1
     # via torch-geometric
@@ -171,13 +178,13 @@ toml==0.10.2
     #   pre-commit
 tomli==2.0.1
     # via
+    #   build
     #   coverage
     #   mypy
-    #   pep517
     #   pytest
 toposort==1.7
     # via pip-compile-multi
-torch==1.11.0
+torch==1.12.0
     # via -r requirements/main.in
 torch-cluster==1.6.0
     # via -r requirements/main.in
@@ -199,7 +206,7 @@ typing-extensions==4.2.0
     #   torch
 urllib3==1.26.9
     # via requests
-virtualenv==20.14.1
+virtualenv==20.15.1
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/requirements/main_3.9.txt
+++ b/requirements/main_3.9.txt
@@ -6,9 +6,9 @@
 #
 --find-links https://data.pyg.org/whl/torch-1.10.0+cu113.html
 
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 googledrivedownloader==0.4
     # via torch-geometric
@@ -24,13 +24,13 @@ markupsafe==2.1.1
     # via jinja2
 mpmath==1.2.1
     # via sympy
-networkx==2.8.2
+networkx==2.8.4
     # via
     #   -r requirements/main.in
     #   torch-geometric
-numexpr==2.8.1
+numexpr==2.8.3
     # via tables
-numpy==1.22.4
+numpy==1.23.0
     # via
     #   numexpr
     #   pandas
@@ -43,7 +43,7 @@ packaging==21.3
     # via
     #   numexpr
     #   tables
-pandas==1.4.2
+pandas==1.4.3
     # via torch-geometric
 pillow==9.1.1
     # via rdkit-pypi
@@ -62,9 +62,9 @@ pyyaml==6.0
     #   yacs
 rdflib==6.1.1
     # via torch-geometric
-rdkit-pypi==2022.3.2.1
+rdkit-pypi==2022.3.3
     # via -r requirements/main.in
-requests==2.27.1
+requests==2.28.1
     # via torch-geometric
 scikit-learn==1.1.1
     # via torch-geometric
@@ -84,7 +84,7 @@ tables==3.7.0
     # via -r requirements/main.in
 threadpoolctl==3.1.0
     # via scikit-learn
-torch==1.11.0
+torch==1.12.0
     # via -r requirements/main.in
 torch-cluster==1.6.0
     # via -r requirements/main.in


### PR DESCRIPTION
# What?
lock dependencies
# Why?
Monthly maintenace
# Notes:
```

                           ____         ___
                         ,' __ ``.._..''   `.
                         `.`. ``-.___..-.    :
 ,---..____________________>/          _,'_  |
 `-:._,:_|_|_|_|_|_|_|_|_|_|_|.:SSt:.:|-|(/  |
                        _.' )   ____  '-'    ;
                       (    `-''  __``-'    /
                        ``-....-''  ``-..-''
                               ||`
                               ||   ''
     '||''| .|''|,  '''|.  .|''||   ||  .|''|,
      ||    ||  || .|''||  ||  ||   ||  ||..||
     .||.   `|..|' `|..||. `|..||. .||. `|...
python
	 version: 3.9.7
	location: /usr/local/bin/python
roadie
	 version: 5.1.16
	location: /usr/local/lib/python3.9/site-packages/roadie
✓ Retrieving roadie-enabled Python interpreters
Found roadie for the following Python versions: 3.7, 3.8, 3.9, 3.10
✓ Attempting to lock for Python 3.9
✓ Attempting to lock for Python 3.8
✗ Attempting to lock for Python 3.10
Failed to lock Python 3.10 using /root/.pyenv/versions/3.10.0/bin/roadie:

                           ____         ___
	                         ,' __ ``.._..''   `.
	                         `.`. ``-.___..-.    :
	 ,---..____________________>/          _,'_  |
	 `-:._,:_|_|_|_|_|_|_|_|_|_|_|.:SSt:.:|-|(/  |
	                        _.' )   ____  '-'    ;
	                       (    `-''  __``-'    /
	                        ``-....-''  ``-..-''

	                               ||`
	                               ||   ''
	     '||''| .|''|,  '''|.  .|''||   ||  .|''|,
	      ||    ||  || .|''||  ||  ||   ||  ||..||
	     .||.   `|..|' `|..||. `|..||. .||. `|...

	python
		 version: 3.10.0
		location: /root/.pyenv/versions/3.10.0/bin/python3.10
	roadie
		 version: 5.1.16
		location: /root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/roadie


✓ Sorting Requirements

✗ Generating lock file for requirements/dev.in
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		ERROR:pip.subprocessor:[present-diagnostic] python setup.py egg_info exited with 1
		Traceback (most recent call last):
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/operations/build/metadata_legacy.py", line 64, in generate_metadata
		    call_subprocess(
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/utils/subprocess.py", line 224, in call_subprocess
		    raise error
		pip._internal.exceptions.InstallationSubprocessError: python setup.py egg_info exited with 1

		The above exception was the direct cause of the following exception:

		Traceback (most recent call last):
		  File "/root/.pyenv/versions/3.10.0/bin/pip-compile", line 8, in <module>
		    sys.exit(cli())
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
		    return self.main(*args, **kwargs)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1055, in main
		    rv = self.invoke(ctx)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
		    return ctx.invoke(self.callback, **ctx.params)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 760, in invoke
		    return __callback(*args, **kwargs)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
		    return f(get_current_context(), *args, **kwargs)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/piptools/scripts/compile.py", line 466, in cli
		    results = resolver.resolve(max_rounds=max_rounds)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/piptools/resolver.py", line 175, in resolve
		    has_changed, best_matches = self._resolve_one_round()
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/piptools/resolver.py", line 319, in _resolve_one_round
		    their_constraints.extend(self._iter_dependencies(best_match))
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/piptools/resolver.py", line 428, in _iter_dependencies
		    dependencies = self.repository.get_dependencies(ireq)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/piptools/repositories/pypi.py", line 238, in get_dependencies
		    self._dependencies_cache[ireq] = self.resolve_reqs(
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/piptools/repositories/pypi.py", line 201, in resolve_reqs
		    results = resolver._resolve_one(reqset, ireq)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/resolution/legacy/resolver.py", line 379, in _resolve_one
		    dist = self._get_dist_for(req_to_install)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/resolution/legacy/resolver.py", line 332, in _get_dist_for
		    dist = self.preparer.prepare_linked_requirement(req)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 487, in prepare_linked_requirement
		    return self._prepare_linked_requirement(req, parallel_builds)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 556, in _prepare_linked_requirement
		    dist = _get_prepared_distribution(
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 58, in _get_prepared_distribution
		    abstract_dist.prepare_distribution_metadata(finder, build_isolation)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/distributions/sdist.py", line 47, in prepare_distribution_metadata
		    self.req.prepare_metadata()
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/req/req_install.py", line 528, in prepare_metadata
		    self.metadata_directory = generate_metadata_legacy(
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/operations/build/metadata_legacy.py", line 71, in generate_metadata
		    raise MetadataGenerationFailed(package_details=details) from error
		pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed

	Some equipment was damaged when loading the bus check logs above for more information.

	Do not forget to commit generated files and review warnings and errors
	
✓ Attempting to lock for Python 3.7

```