### PR TITLE
chore: relock dependencies

### DIFF
--- a/requirements/dev_3.9.txt
+++ b/requirements/dev_3.9.txt
@@ -6,30 +6,32 @@
 #
 --find-links https://data.pyg.org/whl/torch-1.10.0+cu113.html
 
-attrs==21.4.0
+attrs==22.1.0
     # via pytest
 bandit[toml]==1.7.4
     # via -r requirements/dev.in
-certifi==2022.5.18.1
+build==0.8.0
+    # via pip-tools
+certifi==2022.6.15
     # via requests
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 click==8.1.3
     # via
     #   pip-compile-multi
     #   pip-tools
     #   safety
-coverage[toml]==6.4
+coverage[toml]==6.4.2
     # via pytest-cov
-distlib==0.3.4
+distlib==0.3.5
     # via virtualenv
 dparse==0.5.1
     # via safety
 filelock==3.7.1
     # via virtualenv
-flake8==4.0.1
+flake8==5.0.1
     # via -r requirements/dev.in
 gitdb==4.0.9
     # via gitpython
@@ -37,7 +39,7 @@ gitpython==3.1.27
     # via bandit
 googledrivedownloader==0.4
     # via torch-geometric
-identify==2.5.1
+identify==2.5.2
     # via pre-commit
 idna==3.3
     # via requests
@@ -53,23 +55,23 @@ joblib==1.1.0
     # via scikit-learn
 markupsafe==2.1.1
     # via jinja2
-mccabe==0.6.1
+mccabe==0.7.0
     # via flake8
 mpmath==1.2.1
     # via sympy
-mypy==0.960
+mypy==0.971
     # via -r requirements/dev.in
 mypy-extensions==0.4.3
     # via mypy
-networkx==2.8.2
+networkx==2.8.5
     # via
     #   -r requirements/main.in
     #   torch-geometric
-nodeenv==1.6.0
+nodeenv==1.7.0
     # via pre-commit
-numexpr==2.8.1
+numexpr==2.8.3
     # via tables
-numpy==1.22.4
+numpy==1.23.1
     # via
     #   numexpr
     #   pandas
@@ -80,34 +82,35 @@ numpy==1.22.4
     #   torch-geometric
 packaging==21.3
     # via
+    #   build
     #   dparse
     #   numexpr
     #   pytest
     #   safety
     #   tables
-pandas==1.4.2
+pandas==1.4.3
     # via torch-geometric
 pbr==5.9.0
     # via stevedore
-pep517==0.12.0
-    # via pip-tools
-pillow==9.1.1
+pep517==0.13.0
+    # via build
+pillow==9.2.0
     # via rdkit-pypi
-pip-compile-multi==2.4.5
+pip-compile-multi==2.4.6
     # via -r requirements/dev.in
-pip-tools==6.6.2
+pip-tools==6.8.0
     # via pip-compile-multi
 platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via pytest
-pre-commit==2.19.0
+pre-commit==2.20.0
     # via -r requirements/dev.in
 py==1.11.0
     # via pytest
-pycodestyle==2.8.0
+pycodestyle==2.9.0
     # via flake8
-pyflakes==2.4.0
+pyflakes==2.5.0
     # via flake8
 pyparsing==3.0.9
     # via
@@ -133,17 +136,21 @@ pyyaml==6.0
     #   yacs
 rdflib==6.1.1
     # via torch-geometric
-rdkit-pypi==2022.3.2.1
+rdkit-pypi==2022.3.4
     # via -r requirements/main.in
-requests==2.27.1
+requests==2.28.1
     # via
     #   safety
     #   torch-geometric
-safety==1.10.3
+ruamel-yaml==0.17.21
+    # via safety
+ruamel-yaml-clib==0.2.6
+    # via ruamel-yaml
+safety==2.1.1
     # via -r requirements/dev.in
 scikit-learn==1.1.1
     # via torch-geometric
-scipy==1.8.1
+scipy==1.9.0
     # via
     #   -r requirements/main.in
     #   scikit-learn
@@ -153,10 +160,9 @@ six==1.16.0
     # via
     #   isodate
     #   python-dateutil
-    #   virtualenv
 smmap==5.0.0
     # via gitdb
-stevedore==3.5.0
+stevedore==4.0.0
     # via bandit
 sympy==1.10.1
     # via -r requirements/main.in
@@ -171,13 +177,13 @@ toml==0.10.2
     #   pre-commit
 tomli==2.0.1
     # via
+    #   build
     #   coverage
     #   mypy
-    #   pep517
     #   pytest
 toposort==1.7
     # via pip-compile-multi
-torch==1.11.0
+torch==1.12.0
     # via -r requirements/main.in
 torch-cluster==1.6.0
     # via -r requirements/main.in
@@ -193,13 +199,13 @@ typeguard==2.13.3
     # via -r requirements/dev.in
 types-pkg-resources==0.1.3
     # via -r requirements/dev.in
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   mypy
     #   torch
-urllib3==1.26.9
+urllib3==1.26.11
     # via requests
-virtualenv==20.14.1
+virtualenv==20.16.2
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/requirements/main_3.9.txt
+++ b/requirements/main_3.9.txt
@@ -6,9 +6,9 @@
 #
 --find-links https://data.pyg.org/whl/torch-1.10.0+cu113.html
 
-certifi==2022.5.18.1
+certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 googledrivedownloader==0.4
     # via torch-geometric
@@ -24,13 +24,13 @@ markupsafe==2.1.1
     # via jinja2
 mpmath==1.2.1
     # via sympy
-networkx==2.8.2
+networkx==2.8.5
     # via
     #   -r requirements/main.in
     #   torch-geometric
-numexpr==2.8.1
+numexpr==2.8.3
     # via tables
-numpy==1.22.4
+numpy==1.23.1
     # via
     #   numexpr
     #   pandas
@@ -43,9 +43,9 @@ packaging==21.3
     # via
     #   numexpr
     #   tables
-pandas==1.4.2
+pandas==1.4.3
     # via torch-geometric
-pillow==9.1.1
+pillow==9.2.0
     # via rdkit-pypi
 pyparsing==3.0.9
     # via
@@ -62,13 +62,13 @@ pyyaml==6.0
     #   yacs
 rdflib==6.1.1
     # via torch-geometric
-rdkit-pypi==2022.3.2.1
+rdkit-pypi==2022.3.4
     # via -r requirements/main.in
-requests==2.27.1
+requests==2.28.1
     # via torch-geometric
 scikit-learn==1.1.1
     # via torch-geometric
-scipy==1.8.1
+scipy==1.9.0
     # via
     #   -r requirements/main.in
     #   scikit-learn
@@ -84,7 +84,7 @@ tables==3.7.0
     # via -r requirements/main.in
 threadpoolctl==3.1.0
     # via scikit-learn
-torch==1.11.0
+torch==1.12.0
     # via -r requirements/main.in
 torch-cluster==1.6.0
     # via -r requirements/main.in
@@ -96,9 +96,9 @@ torch-sparse==0.6.13
     # via -r requirements/main.in
 tqdm==4.64.0
     # via torch-geometric
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via torch
-urllib3==1.26.9
+urllib3==1.26.11
     # via requests
 yacs==0.1.8
     # via torch-geometric


### PR DESCRIPTION
# What?
lock dependencies
# Why?
Monthly maintenace
# Notes:
```

                           ____         ___
                         ,' __ ``.._..''   `.
                         `.`. ``-.___..-.    :
 ,---..____________________>/          _,'_  |
 `-:._,:_|_|_|_|_|_|_|_|_|_|_|.:SSt:.:|-|(/  |
                        _.' )   ____  '-'    ;
                       (    `-''  __``-'    /
                        ``-....-''  ``-..-''
                               ||`
                               ||   ''
     '||''| .|''|,  '''|.  .|''||   ||  .|''|,
      ||    ||  || .|''||  ||  ||   ||  ||..||
     .||.   `|..|' `|..||. `|..||. .||. `|...
python
	 version: 3.9.7
	location: /usr/local/bin/python
roadie
	 version: 5.1.16
	location: /usr/local/lib/python3.9/site-packages/roadie
✓ Retrieving roadie-enabled Python interpreters
Found roadie for the following Python versions: 3.7, 3.8, 3.9, 3.10
✗ Attempting to lock for Python 3.10
Failed to lock Python 3.10 using /root/.pyenv/versions/3.10.0/bin/roadie:

                           ____         ___
	                         ,' __ ``.._..''   `.
	                         `.`. ``-.___..-.    :
	 ,---..____________________>/          _,'_  |
	 `-:._,:_|_|_|_|_|_|_|_|_|_|_|.:SSt:.:|-|(/  |
	                        _.' )   ____  '-'    ;
	                       (    `-''  __``-'    /
	                        ``-....-''  ``-..-''

	                               ||`
	                               ||   ''
	     '||''| .|''|,  '''|.  .|''||   ||  .|''|,
	      ||    ||  || .|''||  ||  ||   ||  ||..||
	     .||.   `|..|' `|..||. `|..||. .||. `|...

	python
		 version: 3.10.0
		location: /root/.pyenv/versions/3.10.0/bin/python3.10
	roadie
		 version: 5.1.16
		location: /root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/roadie


✓ Sorting Requirements

✗ Generating lock file for requirements/dev.in
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		WARNING:pip._internal.index.collector:[present-diagnostic] <MissingHTMLDoctypeDeclaration: missing-index-doctype>
		ERROR:pip.subprocessor:[present-diagnostic] python setup.py egg_info exited with 1
		Traceback (most recent call last):
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/operations/build/metadata_legacy.py", line 64, in generate_metadata
		    call_subprocess(
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/utils/subprocess.py", line 224, in call_subprocess
		    raise error
		pip._internal.exceptions.InstallationSubprocessError: python setup.py egg_info exited with 1

		The above exception was the direct cause of the following exception:

		Traceback (most recent call last):
		  File "/root/.pyenv/versions/3.10.0/bin/pip-compile", line 8, in <module>
		    sys.exit(cli())
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
		    return self.main(*args, **kwargs)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1055, in main
		    rv = self.invoke(ctx)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
		    return ctx.invoke(self.callback, **ctx.params)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/core.py", line 760, in invoke
		    return __callback(*args, **kwargs)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
		    return f(get_current_context(), *args, **kwargs)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/piptools/scripts/compile.py", line 466, in cli
		    results = resolver.resolve(max_rounds=max_rounds)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/piptools/resolver.py", line 175, in resolve
		    has_changed, best_matches = self._resolve_one_round()
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/piptools/resolver.py", line 319, in _resolve_one_round
		    their_constraints.extend(self._iter_dependencies(best_match))
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/piptools/resolver.py", line 428, in _iter_dependencies
		    dependencies = self.repository.get_dependencies(ireq)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/piptools/repositories/pypi.py", line 238, in get_dependencies
		    self._dependencies_cache[ireq] = self.resolve_reqs(
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/piptools/repositories/pypi.py", line 201, in resolve_reqs
		    results = resolver._resolve_one(reqset, ireq)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/resolution/legacy/resolver.py", line 379, in _resolve_one
		    dist = self._get_dist_for(req_to_install)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/resolution/legacy/resolver.py", line 332, in _get_dist_for
		    dist = self.preparer.prepare_linked_requirement(req)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 487, in prepare_linked_requirement
		    return self._prepare_linked_requirement(req, parallel_builds)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 556, in _prepare_linked_requirement
		    dist = _get_prepared_distribution(
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 58, in _get_prepared_distribution
		    abstract_dist.prepare_distribution_metadata(finder, build_isolation)
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/distributions/sdist.py", line 47, in prepare_distribution_metadata
		    self.req.prepare_metadata()
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/req/req_install.py", line 528, in prepare_metadata
		    self.metadata_directory = generate_metadata_legacy(
		  File "/root/.pyenv/versions/3.10.0/lib/python3.10/site-packages/pip/_internal/operations/build/metadata_legacy.py", line 71, in generate_metadata
		    raise MetadataGenerationFailed(package_details=details) from error
		pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed

	Some equipment was damaged when loading the bus check logs above for more information.

	Do not forget to commit generated files and review warnings and errors
	
✓ Attempting to lock for Python 3.9
✓ Attempting to lock for Python 3.7
✓ Attempting to lock for Python 3.8

```