### PR TITLE
Extract graph sampler from TB

### DIFF
--- a/src/gflownet/algo/graph_sampling.py
+++ b/src/gflownet/algo/graph_sampling.py
@@ -1,5 +1,4 @@
 import copy
-from itertools import count
 from typing import List
 
 import torch
@@ -10,11 +9,28 @@ from gflownet.envs.graph_building_env import GraphActionType
 
 
 class GraphSampler:
+    """A helper class to sample from GraphActionCategorical-producing models"""
     def __init__(self, ctx, env, max_len, max_nodes, rng, sample_temp=1):
+        """
+        Parameters
+        ----------
+        env: GraphBuildingEnv
+            A graph environment.
+        ctx: GraphBuildingEnvContext
+            A context.
+        max_len: int
+            If not None, ends trajectories of more than max_len steps.
+        max_nodes: int
+            If not None, ends trajectories of graphs with more than max_nodes steps (illegal action).
+        rng: np.random.RandomState
+            rng used to take random actions
+        sample_temp: float
+            [Experimental] Softmax temperature used when sampling
+        """
         self.ctx = ctx
         self.env = env
-        self.max_len = max_len
-        self.max_nodes = max_nodes
+        self.max_len = max_len if max_len is not None else 128
+        self.max_nodes = max_nodes if max_nodes is not None else 128
         self.rng = rng
         # Experimental flags
         self.sample_temp = sample_temp
@@ -22,7 +38,29 @@ class GraphSampler:
         self.sanitize_samples = True
 
     def sample_from_model(self, model: nn.Module, n: int, cond_info: Tensor, dev: torch.device):
-        # This will be returned as training data
+        """Samples a model in a minibatch
+
+        Parameters
+        ----------
+        model: nn.Module
+            Model whose forward() method returns GraphActionCategorical instances
+        n: int
+            Number of graphs to sample
+        cond_info: Tensor
+            Conditional information of each trajectory, shape (n, n_info)
+        dev: torch.device
+            Device on which data is manipulated
+
+        Returns
+        -------
+        data: List[Dict]
+           A list of trajectories. Each trajectory is a dict with keys
+           - trajs: List[Tuple[Graph, GraphAction]], the list of states and actions
+           - fwd_logprob: sum logprobs P_F
+           - bck_logprob: sum logprobs P_B
+           - is_valid: is the generated graph valid according to the env & ctx
+        """
+        # This will be returned
         data = [{'traj': [], 'reward_pred': None, 'is_valid': True} for i in range(n)]
         # Let's also keep track of trajectory statistics according to the model
         zero = torch.tensor([0], device=dev).float()
@@ -35,7 +73,7 @@ class GraphSampler:
         def not_done(lst):
             return [e for i, e in enumerate(lst) if not done[i]]
 
-        for t in (range(self.max_len) if self.max_len is not None else count(0)):
+        for t in range(self.max_len):
             # Construct graphs for the trajectories that aren't yet done
             torch_graphs = [self.ctx.graph_to_Data(i) for i in not_done(graphs)]
             not_done_mask = torch.tensor(done, device=dev).logical_not()
@@ -43,12 +81,16 @@ class GraphSampler:
             fwd_cat, log_reward_preds = model(self.ctx.collate(torch_graphs).to(dev), cond_info[not_done_mask])
             if self.random_action_prob > 0:
                 masks = [1] * len(fwd_cat.logits) if fwd_cat.masks is None else fwd_cat.masks
+                # Device which graphs in the minibatch will get their action randomized
                 is_random_action = torch.tensor(
                     self.rng.uniform(size=len(torch_graphs)) < self.random_action_prob, device=dev).float()
+                # Set the logits to some large value if they're not masked, this way the masked
+                # actions have no probability of getting sampled, and there is a uniform
+                # distribution over the rest
                 fwd_cat.logits = [
                     # We don't multiply m by i on the right because we're assume the model forward()
                     # method already does that
-                    is_random_action[b][:, None] * torch.ones_like(i) * m + i * (1 - is_random_action[b][:, None])
+                    is_random_action[b][:, None] * torch.ones_like(i) * m * 100 + i * (1 - is_random_action[b][:, None])
                     for i, m, b in zip(fwd_cat.logits, masks, fwd_cat.batch)
                 ]
             if self.sample_temp != 1:
@@ -59,12 +101,12 @@ class GraphSampler:
                 actions = fwd_cat.sample()
             graph_actions = [self.ctx.aidx_to_GraphAction(g, a) for g, a in zip(torch_graphs, actions)]
             log_probs = fwd_cat.log_prob(actions)
+            # Step each trajectory, and accumulate statistics
             for i, j in zip(not_done(range(n)), range(n)):
-                # Step each trajectory, and accumulate statistics
                 fwd_logprob[i].append(log_probs[j].unsqueeze(0))
                 data[i]['traj'].append((graphs[i], graph_actions[j]))
                 # Check if we're done
-                if graph_actions[j].action is GraphActionType.Stop or (self.max_len and t == self.max_len - 1):
+                if graph_actions[j].action is GraphActionType.Stop or t == self.max_len - 1:
                     done[i] = True
                     if self.sanitize_samples and not self.ctx.is_sane(graphs[i]):
                         # check if the graph is sane (e.g. RDKit can
@@ -76,13 +118,12 @@ class GraphSampler:
                     try:
                         # self.env.step can raise AssertionError if the action is illegal
                         gp = self.env.step(graphs[i], graph_actions[j])
-                        if self.max_nodes is not None:
-                            assert len(gp.nodes) <= self.max_nodes
+                        assert len(gp.nodes) <= self.max_nodes
                     except AssertionError:
                         done[i] = True
                         data[i]['is_valid'] = False
                         continue
-                    # Add to the trajectory
+                    # If no error, add to the trajectory
                     # P_B = uniform backward
                     n_back = self.env.count_backward_transitions(gp)
                     bck_logprob[i].append(torch.tensor([1 / n_back], device=dev).log())
@@ -93,7 +134,7 @@ class GraphSampler:
         for i in range(n):
             # If we're not bootstrapping, we could query the reward
             # model here, but this is expensive/impractical.  Instead
-            # just report forward and backward flows
+            # just report forward and backward logprobs
             data[i]['fwd_logprob'] = sum(fwd_logprob[i])
             data[i]['bck_logprob'] = sum(bck_logprob[i])
         return data

--- a/src/gflownet/algo/graph_sampling.py
+++ b/src/gflownet/algo/graph_sampling.py
@@ -1,0 +1,120 @@
+import copy
+from itertools import count
+from typing import List, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor
+import torch.nn as nn
+
+from gflownet.envs.graph_building_env import GraphActionCategorical
+from gflownet.envs.graph_building_env import GraphActionType
+
+
+class GraphSampler:
+    def __init__(self, ctx, env, max_len, max_nodes, rng, sample_temp=1):
+        self.ctx = ctx
+        self.env = env
+        self.max_len = max_len
+        self.max_nodes = max_nodes
+        self.rng = rng
+        # Experimental flags
+        self.sample_temp = sample_temp
+        self.random_action_prob = 0
+        self.sanitize_samples = True
+
+    def _corrupt_actions(self, actions: List[Tuple[int, int, int]], cat: GraphActionCategorical):
+        """Sample from the uniform policy with probability `self.random_action_prob`"""
+        # TODO: retire this method, make sure nothing depends on it
+        # Should this be a method of GraphActionCategorical?
+        if self.random_action_prob <= 0:
+            return
+        corrupted, = (self.rng.uniform(size=len(actions)) < self.random_action_prob).nonzero()
+        for i in corrupted:
+            n_in_batch = [int((b == i).sum()) for b in cat.batch]
+            n_each = np.array([float(logit.shape[1]) * nb for logit, nb in zip(cat.logits, n_in_batch)])
+            which = self.rng.choice(len(n_each), p=n_each / n_each.sum())
+            row = self.rng.choice(n_in_batch[which])
+            col = self.rng.choice(cat.logits[which].shape[1])
+            actions[i] = (which, row, col)
+
+    def sample_from_model(self, model: nn.Module, n: int, cond_info: Tensor, dev: torch.device):
+        # This will be returned as training data
+        data = [{'traj': [], 'reward_pred': None, 'is_valid': True} for i in range(n)]
+        # Let's also keep track of trajectory statistics according to the model
+        zero = torch.tensor([0], device=dev).float()
+        fwd_logprob: List[List[Tensor]] = [[] for i in range(n)]
+        bck_logprob: List[List[Tensor]] = [[zero] for i in range(n)]  # zero in case there is a single invalid action
+
+        graphs = [self.env.new() for i in range(n)]
+        done = [False] * n
+
+        def not_done(lst):
+            return [e for i, e in enumerate(lst) if not done[i]]
+
+        for t in (range(self.max_len) if self.max_len is not None else count(0)):
+            # Construct graphs for the trajectories that aren't yet done
+            torch_graphs = [self.ctx.graph_to_Data(i) for i in not_done(graphs)]
+            not_done_mask = torch.tensor(done, device=dev).logical_not()
+            # Forward pass to get GraphActionCategorical
+            fwd_cat, log_reward_preds = model(self.ctx.collate(torch_graphs).to(dev), cond_info[not_done_mask])
+            if self.random_action_prob > 0:
+                masks = [1] * len(fwd_cat.logits) if fwd_cat.masks is None else fwd_cat.masks
+                is_random_action = torch.tensor(
+                    self.rng.uniform(size=len(torch_graphs)) < self.random_action_prob,
+                    device=dev
+                ).float()
+                fwd_cat.logits = [
+                    # We don't multiply m by i on the right because we're assume the model forward()
+                    # method already does that
+                    is_random_action[b][:, None] * torch.ones_like(i) * m + i * (1 - is_random_action[b][:, None])
+                    for i, m, b in zip(fwd_cat.logits, masks, fwd_cat.batch)
+                ]
+            if self.sample_temp != 1:
+                sample_cat = copy.copy(fwd_cat)
+                sample_cat.logits = [i / self.sample_temp for i in fwd_cat.logits]
+                actions = sample_cat.sample()
+            else:
+                actions = fwd_cat.sample()
+            # This is broken when there are masks
+            # self._corrupt_actions(actions, fwd_cat)
+            graph_actions = [self.ctx.aidx_to_GraphAction(g, a) for g, a in zip(torch_graphs, actions)]
+            log_probs = fwd_cat.log_prob(actions)
+            for i, j in zip(not_done(range(n)), range(n)):
+                # Step each trajectory, and accumulate statistics
+                fwd_logprob[i].append(log_probs[j].unsqueeze(0))
+                data[i]['traj'].append((graphs[i], graph_actions[j]))
+                # Check if we're done
+                if graph_actions[j].action is GraphActionType.Stop or (self.max_len and t == self.max_len - 1):
+                    done[i] = True
+                    if self.sanitize_samples and not self.ctx.is_sane(graphs[i]):
+                        # check if the graph is sane (e.g. RDKit can
+                        # construct a molecule from it) otherwise
+                        # treat the done action as illegal
+                        data[i]['is_valid'] = False
+                else:  # If not done, try to step the self.environment
+                    gp = graphs[i]
+                    try:
+                        # self.env.step can raise AssertionError if the action is illegal
+                        gp = self.env.step(graphs[i], graph_actions[j])
+                        if self.max_nodes is not None:
+                            assert len(gp.nodes) <= self.max_nodes
+                    except AssertionError:
+                        done[i] = True
+                        data[i]['is_valid'] = False
+                        continue
+                    # Add to the trajectory
+                    # P_B = uniform backward
+                    n_back = self.env.count_backward_transitions(gp)
+                    bck_logprob[i].append(torch.tensor([1 / n_back], device=dev).log())
+                    graphs[i] = gp
+            if all(done):
+                break
+
+        for i in range(n):
+            # If we're not bootstrapping, we could query the reward
+            # model here, but this is expensive/impractical.  Instead
+            # just report forward and backward flows
+            data[i]['fwd_logprob'] = sum(fwd_logprob[i])
+            data[i]['bck_logprob'] = sum(bck_logprob[i])
+        return data

--- a/src/gflownet/envs/graph_building_env.py
+++ b/src/gflownet/envs/graph_building_env.py
@@ -351,7 +351,7 @@ def generate_forward_trajectory(g: Graph, max_nodes: int = None) -> List[Tuple[G
 
 class GraphActionCategorical:
     def __init__(self, graphs: gd.Batch, logits: List[torch.Tensor], keys: List[str], types: List[GraphActionType],
-                 deduplicate_edge_index=True):
+                 deduplicate_edge_index=True, masks: List[torch.Tensor] = None):
         """A multi-type Categorical compatible with generating structured actions.
 
         What is meant by type here is that there are multiple types of
@@ -389,14 +389,19 @@ class GraphActionCategorical:
         deduplicate_edge_index: bool, default=True
            If true, this means that the 'edge_index' keys have been reduced
            by e_i[::2] (presumably because the graphs are undirected)
+        masks: List[Tensor], default=None
+           If not None, a list of broadcastable tensors that multiplicatively
+           mask out logits of invalid actions
         """
-        # TODO: handle legal action masks? (e.g. can't add a node attr to a node that already has an attr)
         self.num_graphs = graphs.num_graphs
         # The logits
         self.logits = logits
         self.types = types
         self.keys = keys
         self.dev = dev = graphs.x.device
+        # TODO: this is only used by graph_sampler, but maybe we should be more careful with it
+        # (e.g. in a softmax and such)
+        self.masks = masks
 
         # I'm extracting batches and slices in a slightly hackish way,
         # but I'm not aware of a proper API to torch_geometric that

--- a/src/gflownet/models/graph_transformer.py
+++ b/src/gflownet/models/graph_transformer.py
@@ -202,5 +202,7 @@ class GraphTransformerFragGFN(nn.Module):
             ],
             keys=[None, 'x', 'edge_index'],
             types=self.action_type_order,
+            masks=[torch.ones(1), g.add_node_mask.cpu(),
+                   g.set_edge_attr_mask.cpu()],
         )
         return cat, self.emb2reward(graph_embeddings)


### PR DESCRIPTION
This makes GraphSampler its own class instead of a method of `TrajectoryBalance`. It will be reused for other algorithms.

* adds proper masking for GraphActionCategoricals, although more functionality can still be added here.
* removes `_corrupt_actions` in `TrajectoryBalance`. `GraphSampler.sample_from_model` now instead relies on masks to take random action in the event that `GraphSampler.random_action_prob > 0`.