### PR TITLE
chore: relock dependencies

### DIFF
--- a/requirements/dev_3.9.txt
+++ b/requirements/dev_3.9.txt
@@ -12,7 +12,7 @@ bandit[toml]==1.7.4
     # via -r requirements/dev.in
 build==0.8.0
     # via pip-tools
-certifi==2022.6.15
+certifi==2022.9.24
     # via requests
 cfgv==3.3.1
     # via pre-commit
@@ -23,11 +23,11 @@ click==8.1.3
     #   pip-compile-multi
     #   pip-tools
     #   safety
-coverage[toml]==6.4.4
+coverage[toml]==6.5.0
     # via pytest-cov
 distlib==0.3.6
     # via virtualenv
-dparse==0.5.2
+dparse==0.6.2
     # via safety
 filelock==3.8.0
     # via virtualenv
@@ -39,9 +39,9 @@ gitpython==3.1.27
     # via bandit
 googledrivedownloader==0.4
     # via torch-geometric
-identify==2.5.3
+identify==2.5.5
     # via pre-commit
-idna==3.3
+idna==3.4
     # via requests
 iniconfig==1.1.1
     # via pytest
@@ -59,7 +59,7 @@ mccabe==0.7.0
     # via flake8
 mpmath==1.2.1
     # via sympy
-mypy==0.971
+mypy==0.981
     # via -r requirements/dev.in
 mypy-extensions==0.4.3
     # via mypy
@@ -71,7 +71,7 @@ nodeenv==1.7.0
     # via pre-commit
 numexpr==2.8.3
     # via tables
-numpy==1.23.2
+numpy==1.23.3
     # via
     #   numexpr
     #   pandas
@@ -88,7 +88,7 @@ packaging==21.3
     #   pytest
     #   safety
     #   tables
-pandas==1.4.4
+pandas==1.5.0
     # via torch-geometric
 pbr==5.10.0
     # via stevedore
@@ -117,11 +117,11 @@ pyparsing==3.0.9
     #   packaging
     #   rdflib
     #   torch-geometric
-pytest==7.1.2
+pytest==7.1.3
     # via
     #   -r requirements/dev.in
     #   pytest-cov
-pytest-cov==3.0.0
+pytest-cov==4.0.0
     # via -r requirements/dev.in
 python-dateutil==2.8.2
     # via pandas
@@ -145,7 +145,7 @@ ruamel-yaml==0.17.21
     # via safety
 ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
-safety==2.1.1
+safety==2.2.0
     # via -r requirements/dev.in
 scikit-learn==1.1.2
     # via torch-geometric
@@ -192,7 +192,7 @@ torch-scatter==2.0.9
     # via -r requirements/main.in
 torch-sparse==0.6.13
     # via -r requirements/main.in
-tqdm==4.64.0
+tqdm==4.64.1
     # via torch-geometric
 typeguard==2.13.3
     # via -r requirements/dev.in
@@ -204,7 +204,7 @@ typing-extensions==4.3.0
     #   torch
 urllib3==1.26.12
     # via requests
-virtualenv==20.16.4
+virtualenv==20.16.5
     # via pre-commit
 wheel==0.37.1
     # via pip-tools

--- a/requirements/main_3.9.txt
+++ b/requirements/main_3.9.txt
@@ -6,13 +6,13 @@
 #
 --find-links https://data.pyg.org/whl/torch-1.10.0+cu113.html
 
-certifi==2022.6.15
+certifi==2022.9.24
     # via requests
 charset-normalizer==2.1.1
     # via requests
 googledrivedownloader==0.4
     # via torch-geometric
-idna==3.3
+idna==3.4
     # via requests
 isodate==0.6.1
     # via rdflib
@@ -30,7 +30,7 @@ networkx==2.8.6
     #   torch-geometric
 numexpr==2.8.3
     # via tables
-numpy==1.23.2
+numpy==1.23.3
     # via
     #   numexpr
     #   pandas
@@ -43,7 +43,7 @@ packaging==21.3
     # via
     #   numexpr
     #   tables
-pandas==1.4.4
+pandas==1.5.0
     # via torch-geometric
 pillow==9.2.0
     # via rdkit-pypi
@@ -94,7 +94,7 @@ torch-scatter==2.0.9
     # via -r requirements/main.in
 torch-sparse==0.6.13
     # via -r requirements/main.in
-tqdm==4.64.0
+tqdm==4.64.1
     # via torch-geometric
 typing-extensions==4.3.0
     # via torch


### PR DESCRIPTION
# What?
lock dependencies
# Why?
Monthly maintenace
# Notes:
```

python
	 version: 3.9.12
	location: /usr/local/bin/python
roadie
	 version: 6.0.2
	location: /usr/local/lib/python3.9/site-packages/roadie
✓ Retrieving roadie-enabled Python interpreters
Found roadie for the following Python versions: 3.7, 3.8, 3.9, 3.10
✓ Attempting to lock for Python 3.9
✗ Attempting to lock for Python 3.7
Failed to lock Python 3.7 using /root/.pyenv/versions/3.7.13/bin/roadie:

python
		 version: 3.7.13
		location: /root/.pyenv/versions/3.7.13/bin/python3.7
	roadie
		 version: 6.0.2
		location: /root/.pyenv/versions/3.7.13/lib/python3.7/site-packages/roadie


✓ Sorting Requirements

✗ Generating lock file for requirements/dev.in
		Could not find a version that matches importlib-metadata<4.3,>=0.12,>=1.1.0,>=1.7.0,>=4.8.3 (from flake8==5.0.4->-r /codefresh/volume/projects/recursionpharma/gflownet/requirements/dev_sfvjgl9a.in (line 5))
		Tried: 0.0, 0.1, 0.1, 0.2, 0.2, 0.3, 0.3, 0.4, 0.4, 0.5, 0.5, 0.6, 0.6, 0.7, 0.7, 0.8, 0.8, 0.9, 0.9, 0.10, 0.10, 0.11, 0.11, 0.12, 0.12, 0.13, 0.13, 0.14, 0.14, 0.15, 0.15, 0.16, 0.16, 0.17, 0.17, 0.18, 0.18, 0.19, 0.19, 0.20, 0.20, 0.21, 0.21, 0.22, 0.22, 0.23, 0.23, 1.0.0, 1.0.0, 1.1.0, 1.1.0, 1.1.1, 1.1.1, 1.1.2, 1.1.2, 1.1.3, 1.1.3, 1.2.0, 1.2.0, 1.3.0, 1.3.0, 1.4.0, 1.4.0, 1.5.0, 1.5.0, 1.5.1, 1.5.1, 1.5.2, 1.5.2, 1.6.0, 1.6.0, 1.6.1, 1.6.1, 1.7.0, 1.7.0, 2.0.0, 2.0.0, 2.1.0, 2.1.0, 2.1.1, 2.1.1, 2.1.2, 2.1.2, 2.1.3, 2.1.3, 3.0.0, 3.0.0, 3.1.0, 3.1.0, 3.1.1, 3.1.1, 3.2.0, 3.2.0, 3.3.0, 3.3.0, 3.4.0, 3.4.0, 3.5.0, 3.5.0, 3.6.0, 3.6.0, 3.7.0, 3.7.0, 3.7.1, 3.7.1, 3.7.2, 3.7.2, 3.7.3, 3.7.3, 3.8.0, 3.8.0, 3.8.1, 3.8.1, 3.8.2, 3.8.2, 3.9.0, 3.9.0, 3.9.1, 3.9.1, 3.10.0, 3.10.0, 3.10.1, 3.10.1, 4.0.0, 4.0.0, 4.0.1, 4.0.1, 4.1.0, 4.1.0, 4.2.0, 4.2.0, 4.3.0, 4.3.0, 4.3.1, 4.3.1, 4.4.0, 4.4.0, 4.5.0, 4.5.0, 4.6.0, 4.6.0, 4.6.1, 4.6.1, 4.6.2, 4.6.2, 4.6.3, 4.6.3, 4.6.4, 4.6.4, 4.7.0, 4.7.0, 4.7.1, 4.7.1, 4.8.0, 4.8.0, 4.8.1, 4.8.1, 4.8.2, 4.8.2, 4.8.3, 4.8.3, 4.9.0, 4.9.0, 4.10.0, 4.10.0, 4.10.1, 4.10.1, 4.11.0, 4.11.0, 4.11.1, 4.11.1, 4.11.2, 4.11.2, 4.11.3, 4.11.3, 4.11.4, 4.11.4, 4.12.0, 4.12.0
		There are incompatible versions in the resolved dependencies:
		  importlib-metadata (from click==8.1.3->safety==2.2.0->-r /codefresh/volume/projects/recursionpharma/gflownet/requirements/dev_sfvjgl9a.in (line 12))
		  importlib-metadata (from pre-commit==2.20.0->-r /codefresh/volume/projects/recursionpharma/gflownet/requirements/dev_sfvjgl9a.in (line 9))
		  importlib-metadata>=4.8.3 (from virtualenv==20.16.5->pre-commit==2.20.0->-r /codefresh/volume/projects/recursionpharma/gflownet/requirements/dev_sfvjgl9a.in (line 9))
		  importlib-metadata>=0.12 (from pluggy==1.0.0->pytest==7.1.3->-r /codefresh/volume/projects/recursionpharma/gflownet/requirements/dev_sfvjgl9a.in (line 10))
		  importlib-metadata (from rdflib==6.2.0->torch-geometric==2.0.3->-r /codefresh/volume/projects/recursionpharma/gflownet/requirements/main.in (line 8))
		  importlib-metadata>=1.7.0 (from stevedore==3.5.0->bandit[toml]==1.7.4->-r /codefresh/volume/projects/recursionpharma/gflownet/requirements/dev_sfvjgl9a.in (line 4))
		  importlib-metadata<4.3,>=1.1.0 (from flake8==5.0.4->-r /codefresh/volume/projects/recursionpharma/gflownet/requirements/dev_sfvjgl9a.in (line 5))
		  importlib-metadata>=0.12 (from pytest==7.1.3->-r /codefresh/volume/projects/recursionpharma/gflownet/requirements/dev_sfvjgl9a.in (line 10))

	Some equipment was damaged when loading the bus check logs above for more information.

	Do not forget to commit generated files and review warnings and errors
	
✗ Attempting to lock for Python 3.10
Failed to lock Python 3.10 using /root/.pyenv/versions/3.10.4/bin/roadie:

python
		 version: 3.10.4
		location: /root/.pyenv/versions/3.10.4/bin/python3.10
	roadie
		 version: 6.0.2
		location: /root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/roadie


✓ Sorting Requirements

✗ Generating lock file for requirements/dev.in
		    error: subprocess-exited-with-error

		    × python setup.py egg_info did not run successfully.
		    │ exit code: 1
		    ╰─> [6 lines of output]
		        Traceback (most recent call last):
		          File "<string>", line 2, in <module>
		          File "<pip-setuptools-caller>", line 34, in <module>
		          File "/tmp/pip-resolver-rasnl6dg/torch-cluster/setup.py", line 8, in <module>
		            import torch
		        ModuleNotFoundError: No module named 'torch'
		        [end of output]

		    note: This error originates from a subprocess, and is likely not a problem with pip.
		Traceback (most recent call last):
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/pip/_internal/operations/build/metadata_legacy.py", line 64, in generate_metadata
		    call_subprocess(
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/pip/_internal/utils/subprocess.py", line 224, in call_subprocess
		    raise error
		pip._internal.exceptions.InstallationSubprocessError: python setup.py egg_info exited with 1

		The above exception was the direct cause of the following exception:

		Traceback (most recent call last):
		  File "/root/.pyenv/versions/3.10.4/bin/pip-compile", line 8, in <module>
		    sys.exit(cli())
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
		    return self.main(*args, **kwargs)
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/click/core.py", line 1055, in main
		    rv = self.invoke(ctx)
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
		    return ctx.invoke(self.callback, **ctx.params)
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/click/core.py", line 760, in invoke
		    return __callback(*args, **kwargs)
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
		    return f(get_current_context(), *args, **kwargs)
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/piptools/scripts/compile.py", line 487, in cli
		    results = resolver.resolve(max_rounds=max_rounds)
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/piptools/resolver.py", line 266, in resolve
		    has_changed, best_matches = self._resolve_one_round()
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/piptools/resolver.py", line 356, in _resolve_one_round
		    their_constraints.extend(self._iter_dependencies(best_match))
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/piptools/resolver.py", line 469, in _iter_dependencies
		    dependencies = self.repository.get_dependencies(ireq)
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/piptools/repositories/pypi.py", line 250, in get_dependencies
		    self._dependencies_cache[ireq] = self.resolve_reqs(
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/piptools/repositories/pypi.py", line 213, in resolve_reqs
		    results = resolver._resolve_one(reqset, ireq)
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/pip/_internal/resolution/legacy/resolver.py", line 500, in _resolve_one
		    dist = self._get_dist_for(req_to_install)
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/pip/_internal/resolution/legacy/resolver.py", line 453, in _get_dist_for
		    dist = self.preparer.prepare_linked_requirement(req)
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 428, in prepare_linked_requirement
		    return self._prepare_linked_requirement(req, parallel_builds)
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 497, in _prepare_linked_requirement
		    dist = _get_prepared_distribution(
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 58, in _get_prepared_distribution
		    abstract_dist.prepare_distribution_metadata(
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/pip/_internal/distributions/sdist.py", line 61, in prepare_distribution_metadata
		    self.req.prepare_metadata()
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/pip/_internal/req/req_install.py", line 532, in prepare_metadata
		    self.metadata_directory = generate_metadata_legacy(
		  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/pip/_internal/operations/build/metadata_legacy.py", line 71, in generate_metadata
		    raise MetadataGenerationFailed(package_details=details) from error
		pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed

	Some equipment was damaged when loading the bus check logs above for more information.

	Do not forget to commit generated files and review warnings and errors
	
✓ Attempting to lock for Python 3.8

```