### PR TITLE
chore: relock dependencies

### DIFF
--- a/requirements/dev_3.9.txt
+++ b/requirements/dev_3.9.txt
@@ -23,19 +23,19 @@ distlib==0.3.6
     # via virtualenv
 dparse==0.6.2
     # via safety
-exceptiongroup==1.0.0
+exceptiongroup==1.0.4
     # via pytest
 filelock==3.8.0
     # via virtualenv
-flake8==5.0.4
+flake8==6.0.0
     # via -r requirements/dev.in
-gitdb==4.0.9
+gitdb==4.0.10
     # via gitpython
 gitpython==3.1.29
     # via bandit
 googledrivedownloader==0.4
     # via torch-geometric
-identify==2.5.8
+identify==2.5.9
     # via pre-commit
 idna==3.4
     # via requests
@@ -55,11 +55,11 @@ mccabe==0.7.0
     # via flake8
 mpmath==1.2.1
     # via sympy
-mypy==0.982
+mypy==0.991
     # via -r requirements/dev.in
 mypy-extensions==0.4.3
     # via mypy
-networkx==2.8.7
+networkx==2.8.8
     # via
     #   -r requirements/main.in
     #   torch-geometric
@@ -67,7 +67,7 @@ nodeenv==1.7.0
     # via pre-commit
 numexpr==2.8.4
     # via tables
-numpy==1.23.4
+numpy==1.23.5
     # via
     #   numexpr
     #   pandas
@@ -93,7 +93,7 @@ packaging==21.3
     #   pytest
     #   safety
     #   tables
-pandas==1.5.1
+pandas==1.5.2
     # via torch-geometric
 pbr==5.11.0
     # via stevedore
@@ -101,19 +101,19 @@ pep517==0.13.0
     # via build
 pillow==9.3.0
     # via rdkit-pypi
-pip-compile-multi==2.4.6
+pip-compile-multi==2.6.1
     # via -r requirements/dev.in
-pip-tools==6.9.0
+pip-tools==6.11.0
     # via pip-compile-multi
-platformdirs==2.5.2
+platformdirs==2.5.4
     # via virtualenv
 pluggy==1.0.0
     # via pytest
 pre-commit==2.20.0
     # via -r requirements/dev.in
-pycodestyle==2.9.1
+pycodestyle==2.10.0
     # via flake8
-pyflakes==2.5.0
+pyflakes==3.0.1
     # via flake8
 pyparsing==3.0.9
     # via
@@ -138,7 +138,7 @@ pyyaml==6.0
     #   yacs
 rdflib==6.2.0
     # via torch-geometric
-rdkit-pypi==2022.9.1
+rdkit-pypi==2022.9.2
     # via -r requirements/main.in
 requests==2.28.1
     # via
@@ -148,7 +148,7 @@ ruamel-yaml==0.17.21
     # via safety
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
-safety==2.3.1
+safety==2.3.3
     # via -r requirements/dev.in
 scikit-learn==1.1.3
     # via torch-geometric
@@ -164,7 +164,7 @@ six==1.16.0
     #   python-dateutil
 smmap==5.0.0
     # via gitdb
-stevedore==4.1.0
+stevedore==4.1.1
     # via bandit
 sympy==1.11.1
     # via -r requirements/main.in
@@ -205,11 +205,11 @@ typing-extensions==4.4.0
     # via
     #   mypy
     #   torch
-urllib3==1.26.12
+urllib3==1.26.13
     # via requests
-virtualenv==20.16.6
+virtualenv==20.17.0
     # via pre-commit
-wheel==0.38.0
+wheel==0.38.4
     # via
     #   nvidia-cublas-cu11
     #   nvidia-cuda-runtime-cu11

--- a/requirements/main_3.9.txt
+++ b/requirements/main_3.9.txt
@@ -18,13 +18,13 @@ markupsafe==2.1.1
     # via jinja2
 mpmath==1.2.1
     # via sympy
-networkx==2.8.7
+networkx==2.8.8
     # via
     #   -r requirements/main.in
     #   torch-geometric
 numexpr==2.8.4
     # via tables
-numpy==1.23.4
+numpy==1.23.5
     # via
     #   numexpr
     #   pandas
@@ -45,7 +45,7 @@ nvidia-cudnn-cu11==8.5.0.96
     # via torch
 packaging==21.3
     # via tables
-pandas==1.5.1
+pandas==1.5.2
     # via torch-geometric
 pillow==9.3.0
     # via rdkit-pypi
@@ -64,7 +64,7 @@ pyyaml==6.0
     #   yacs
 rdflib==6.2.0
     # via torch-geometric
-rdkit-pypi==2022.9.1
+rdkit-pypi==2022.9.2
     # via -r requirements/main.in
 requests==2.28.1
     # via torch-geometric
@@ -100,9 +100,9 @@ tqdm==4.64.1
     # via torch-geometric
 typing-extensions==4.4.0
     # via torch
-urllib3==1.26.12
+urllib3==1.26.13
     # via requests
-wheel==0.38.0
+wheel==0.38.4
     # via
     #   nvidia-cublas-cu11
     #   nvidia-cuda-runtime-cu11


### PR DESCRIPTION
# What?
lock dependencies
# Why?
Monthly maintenace
# Notes:
```

python
	 version: 3.9.14
	location: /usr/local/bin/python
roadie
	 version: 6.2.0
	location: /usr/local/lib/python3.9/site-packages/roadie
✓ Retrieving roadie-enabled Python interpreters
Found roadie for the following Python versions: 3.7, 3.8, 3.9, 3.10
✗ Attempting to lock for Python 3.10
Failed to lock Python 3.10 using /root/.pyenv/versions/3.10.7/bin/roadie:
/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/yaspin/core.py:59: UserWarning: color, on_color and attrs are not supported when running in jupyter
	  self._color = self._set_color(color) if color else color
	python
		 version: 3.10.7
		location: /root/.pyenv/versions/3.10.7/bin/python3.10
	roadie
		 version: 6.2.0
		location: /root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/roadie
✓ Sorting Requirements
✗ Generating lock file for requirements/dev.in
		    error: subprocess-exited-with-error
		    × python setup.py egg_info did not run successfully.
		    │ exit code: 1
		    ╰─> [6 lines of output]
		        Traceback (most recent call last):
		          File "<string>", line 2, in <module>
		          File "<pip-setuptools-caller>", line 34, in <module>
		          File "/tmp/pip-resolver-uwey4hl8/torch-sparse/setup.py", line 8, in <module>
		            import torch
		        ModuleNotFoundError: No module named 'torch'
		        [end of output]
		    note: This error originates from a subprocess, and is likely not a problem with pip.
		Traceback (most recent call last):
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/operations/build/metadata_legacy.py", line 64, in generate_metadata
		    call_subprocess(
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/utils/subprocess.py", line 224, in call_subprocess
		    raise error
		pip._internal.exceptions.InstallationSubprocessError: python setup.py egg_info exited with 1
		The above exception was the direct cause of the following exception:
		Traceback (most recent call last):
		  File "/root/.pyenv/versions/3.10.7/bin/pip-compile", line 8, in <module>
		    sys.exit(cli())
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
		    return self.main(*args, **kwargs)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/click/core.py", line 1055, in main
		    rv = self.invoke(ctx)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
		    return ctx.invoke(self.callback, **ctx.params)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/click/core.py", line 760, in invoke
		    return __callback(*args, **kwargs)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
		    return f(get_current_context(), *args, **kwargs)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/piptools/scripts/compile.py", line 510, in cli
		    results = resolver.resolve(max_rounds=max_rounds)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/piptools/resolver.py", line 260, in resolve
		    has_changed, best_matches = self._resolve_one_round()
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/piptools/resolver.py", line 350, in _resolve_one_round
		    their_constraints.extend(self._iter_dependencies(best_match))
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/piptools/resolver.py", line 463, in _iter_dependencies
		    dependencies = self.repository.get_dependencies(ireq)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/piptools/repositories/pypi.py", line 250, in get_dependencies
		    self._dependencies_cache[ireq] = self.resolve_reqs(
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/piptools/repositories/pypi.py", line 213, in resolve_reqs
		    results = resolver._resolve_one(reqset, ireq)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/resolution/legacy/resolver.py", line 509, in _resolve_one
		    dist = self._get_dist_for(req_to_install)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/resolution/legacy/resolver.py", line 462, in _get_dist_for
		    dist = self.preparer.prepare_linked_requirement(req)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 491, in prepare_linked_requirement
		    return self._prepare_linked_requirement(req, parallel_builds)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 577, in _prepare_linked_requirement
		    dist = _get_prepared_distribution(
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 69, in _get_prepared_distribution
		    abstract_dist.prepare_distribution_metadata(
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/distributions/sdist.py", line 61, in prepare_distribution_metadata
		    self.req.prepare_metadata()
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/req/req_install.py", line 541, in prepare_metadata
		    self.metadata_directory = generate_metadata_legacy(
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/operations/build/metadata_legacy.py", line 71, in generate_metadata
		    raise MetadataGenerationFailed(package_details=details) from error
		pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
		
	Some equipment was damaged when loading the bus check logs above for more information.
	Do not forget to commit generated files and review warnings and errors
	
Skipping Python 3.7
✓ Attempting to lock for Python 3.9
Skipping Python 3.8

```