### PR TITLE
Add idempotency correction

### DIFF
--- a/src/gflownet/algo/graph_sampling.py
+++ b/src/gflownet/algo/graph_sampling.py
@@ -66,7 +66,6 @@ class GraphSampler:
         # This will be returned
         data = [{'traj': [], 'reward_pred': None, 'is_valid': True} for i in range(n)]
         # Let's also keep track of trajectory statistics according to the model
-        zero = torch.tensor([0], device=dev).float()
         fwd_logprob: List[List[Tensor]] = [[] for i in range(n)]
         bck_logprob: List[List[Tensor]] = [[] for i in range(n)]
 

--- a/src/gflownet/algo/graph_sampling.py
+++ b/src/gflownet/algo/graph_sampling.py
@@ -10,7 +10,7 @@ from gflownet.envs.graph_building_env import GraphActionType
 
 class GraphSampler:
     """A helper class to sample from GraphActionCategorical-producing models"""
-    def __init__(self, ctx, env, max_len, max_nodes, rng, sample_temp=1):
+    def __init__(self, ctx, env, max_len, max_nodes, rng, sample_temp=1, correct_idempotent=False):
         """
         Parameters
         ----------
@@ -26,6 +26,8 @@ class GraphSampler:
             rng used to take random actions
         sample_temp: float
             [Experimental] Softmax temperature used when sampling
+        correct_idempotent: bool
+            [Experimental] Correct for idempotent actions when counting
         """
         self.ctx = ctx
         self.env = env
@@ -36,6 +38,7 @@ class GraphSampler:
         self.sample_temp = sample_temp
         self.random_action_prob = 0
         self.sanitize_samples = True
+        self.correct_idempotent = correct_idempotent
 
     def sample_from_model(self, model: nn.Module, n: int, cond_info: Tensor, dev: torch.device):
         """Samples a model in a minibatch
@@ -124,7 +127,7 @@ class GraphSampler:
                         done[i] = True
                     # If no error, add to the trajectory
                     # P_B = uniform backward
-                    n_back = self.env.count_backward_transitions(gp)
+                    n_back = self.env.count_backward_transitions(gp, check_idempotent=self.correct_idempotent)
                     bck_logprob[i].append(torch.tensor([1 / n_back], device=dev).log())
                     graphs[i] = gp
                 if done[i] and self.sanitize_samples and not self.ctx.is_sane(graphs[i]):

--- a/src/gflownet/algo/trajectory_balance.py
+++ b/src/gflownet/algo/trajectory_balance.py
@@ -74,10 +74,12 @@ class TrajectoryBalance:
         self.length_normalize_losses = False
         self.reward_normalize_losses = False
         self.sample_temp = 1
-        self.graph_sampler = GraphSampler(ctx, env, max_len, max_nodes, rng, self.sample_temp)
-        self.graph_sampler.random_action_prob = hps['random_action_prob']
         self.is_doing_subTB = hps.get('tb_do_subtb', False)
         self.correct_idempotent = hps.get('tb_correct_idempotent', False)
+
+        self.graph_sampler = GraphSampler(ctx, env, max_len, max_nodes, rng, self.sample_temp,
+                                          correct_idempotent=self.correct_idempotent)
+        self.graph_sampler.random_action_prob = hps['random_action_prob']
         if self.is_doing_subTB:
             self._subtb_max_len = hps.get('tb_subtb_max_len', max_len + 1 if max_len is not None else 128)
             self._init_subtb(torch.device('cuda'))  # TODO: where are we getting device info?

--- a/src/gflownet/algo/trajectory_balance.py
+++ b/src/gflownet/algo/trajectory_balance.py
@@ -13,8 +13,8 @@ from gflownet.algo.graph_sampling import GraphSampler
 from gflownet.envs.graph_building_env import generate_forward_trajectory
 from gflownet.envs.graph_building_env import Graph
 from gflownet.envs.graph_building_env import GraphAction
-from gflownet.envs.graph_building_env import GraphActionType
 from gflownet.envs.graph_building_env import GraphActionCategorical
+from gflownet.envs.graph_building_env import GraphActionType
 from gflownet.envs.graph_building_env import GraphBuildingEnv
 from gflownet.envs.graph_building_env import GraphBuildingEnvContext
 

--- a/src/gflownet/algo/trajectory_balance.py
+++ b/src/gflownet/algo/trajectory_balance.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Tuple
 
+import networkx as nx
 import numpy as np
 import torch
 from torch import Tensor
@@ -10,6 +11,7 @@ from torch_scatter import scatter_sum
 
 from gflownet.algo.graph_sampling import GraphSampler
 from gflownet.envs.graph_building_env import generate_forward_trajectory
+from gflownet.envs.graph_building_env import GraphActionType
 from gflownet.envs.graph_building_env import GraphActionCategorical
 from gflownet.envs.graph_building_env import GraphBuildingEnv
 from gflownet.envs.graph_building_env import GraphBuildingEnvContext
@@ -75,6 +77,7 @@ class TrajectoryBalance:
         self.graph_sampler = GraphSampler(ctx, env, max_len, max_nodes, rng, self.sample_temp)
         self.graph_sampler.random_action_prob = hps['random_action_prob']
         self.is_doing_subTB = hps.get('tb_do_subtb', False)
+        self.correct_idempotent = hps.get('tb_correct_idempotent', False)
         if self.is_doing_subTB:
             self._subtb_max_len = hps.get('tb_subtb_max_len', max_len + 1 if max_len is not None else 128)
             self._init_subtb(torch.device('cuda'))  # TODO: where are we getting device info?
@@ -125,6 +128,24 @@ class TrajectoryBalance:
         """
         return [{'traj': generate_forward_trajectory(i)} for i in graphs]
 
+    def get_idempotent_actions(self, g, gd, gp, action):
+        iaction = self.ctx.GraphAction_to_aidx(gd, action)
+        if action.action == GraphActionType.Stop:
+            return [iaction]
+        mask_name = self.ctx.action_mask_names[iaction[0]]
+        lmask = getattr(gd, mask_name)
+        nz = lmask.nonzero()
+        actions = [iaction]
+        for i in nz:
+            aidx = (iaction[0], i[0].item(), i[1].item())
+            if aidx == iaction:
+                continue
+            ga = self.ctx.aidx_to_GraphAction(gd, aidx)
+            child = self.env.step(g, ga)
+            if nx.algorithms.is_isomorphic(child, gp, lambda a, b: a == b, lambda a, b: a == b):
+                actions.append(aidx)
+        return actions
+
     def construct_batch(self, trajs, cond_info, log_rewards):
         """Construct a batch from a list of trajectories and their information
 
@@ -145,20 +166,33 @@ class TrajectoryBalance:
         actions = [
             self.ctx.GraphAction_to_aidx(g, a) for g, a in zip(torch_graphs, [i[1] for tj in trajs for i in tj['traj']])
         ]
-        num_backward = torch.tensor([
-            # Count the number of backward transitions from s_{t+1},
-            # unless t+1 = T is the last time step
-            self.env.count_backward_transitions(tj['traj'][i + 1][0]) if i + 1 < len(tj['traj']) else 1
-            for tj in trajs
-            for i in range(len(tj['traj']))
-        ])
         batch = self.ctx.collate(torch_graphs)
         batch.traj_lens = torch.tensor([len(i['traj']) for i in trajs])
-        batch.num_backward = num_backward
+        batch.log_p_B = torch.cat([i['bck_logprobs'] for i in trajs], 0)
         batch.actions = torch.tensor(actions)
         batch.log_rewards = log_rewards
         batch.cond_info = cond_info
         batch.is_valid = torch.tensor([i.get('is_valid', True) for i in trajs]).float()
+        if self.correct_idempotent:
+            agraphs = [i[0] for tj in trajs for i in tj['traj']]
+            bgraphs = sum([[i[0] for i in tj['traj'][1:]] + [tj['result']] for tj in trajs], [])
+            gactions = [i[1] for tj in trajs for i in tj['traj']]
+            ipa = [
+                self.get_idempotent_actions(g, gd, gp, a)
+                for g, gd, gp, a in zip(agraphs, torch_graphs, bgraphs, gactions)
+            ]
+            batch.ip_actions = torch.tensor(sum(ipa, []))
+            batch.ip_lens = torch.tensor([len(i) for i in ipa])
+
+        if 0:
+            num_backward = torch.tensor([
+                # Count the number of backward transitions from s_{t+1},
+                # unless t+1 = T is the last time step
+                self.env.count_backward_transitions(tj['traj'][i + 1][0]) if i + 1 < len(tj['traj']) else 1
+                for tj in trajs
+                for i in range(len(tj['traj']))
+            ])
+            batch.num_backward = num_backward
         return batch
 
     def compute_batch_losses(self, model: TrajectoryBalanceModel, batch: gd.Batch, num_bootstrap: int = 0):
@@ -194,10 +228,28 @@ class TrajectoryBalance:
         log_reward_preds = per_mol_out[final_graph_idx, 0]
         # Compute trajectory balance objective
         log_Z = model.logZ(cond_info)[:, 0]
-        # This is the log prob of each action in the trajectory
-        log_prob = fwd_cat.log_prob(batch.actions)
+        # Compute the log prob of each action in the trajectory
+        if self.correct_idempotent:
+            # If we want to correct for idempotent actions, we need to sum probabilities
+            # i.e. to compute P(s' | s) = sum_{a that lead to s'} P(a|s)
+            # here we compute the indices of the graph that each action corresponds to, ip_lens
+            # contains the number of  idempotent actions for each transition, so we
+            # repeat_interleave as with batch_idx
+            ip_idces = torch.arange(batch.ip_lens.shape[0], device=dev).repeat_interleave(batch.ip_lens)
+            # get the full logprobs
+            logprobs = fwd_cat.logsoftmax()
+            # batch.ip_actions lists those actions, so we index the logprobs appropriately
+            log_prob = torch.stack(
+                [logprobs[t][row + fwd_cat.slice[t][i], col] for i, (t, row, col) in zip(ip_idces, batch.ip_actions)])
+            # take the logsumexp (because we want to sum probabilities, not log probabilities)
+            # TODO: numerically stable version:
+            log_prob = scatter(log_prob.exp(), ip_idces, dim=0, dim_size=batch_idx.shape[0], reduce='sum').log()
+        else:
+            # Else just naively take the logprob of the actions we took
+            log_prob = fwd_cat.log_prob(batch.actions)
         # The log prob of each backward action
-        log_p_B = (1 / batch.num_backward).log()
+        log_p_B = batch.log_p_B
+        assert log_prob.shape == log_p_B.shape
         # Clip rewards
         assert log_rewards.ndim == 1
         clip_log_R = torch.maximum(log_rewards, torch.tensor(self.illegal_action_logreward, device=dev))

--- a/src/gflownet/data/sampling_iterator.py
+++ b/src/gflownet/data/sampling_iterator.py
@@ -218,9 +218,7 @@ class SamplingIterator(IterableDataset):
                 for i in range(len(trajs))
             ]
         else:
-            mols = [
-                nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(t['result'], None, 'v') for t in trajs
-            ]
+            mols = [nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(t['result'], None, 'v') for t in trajs]
 
         flat_rewards = flat_rewards.reshape((len(flat_rewards), -1)).data.numpy().tolist()
         log_rewards = log_rewards.data.numpy().tolist()

--- a/src/gflownet/data/sampling_iterator.py
+++ b/src/gflownet/data/sampling_iterator.py
@@ -159,7 +159,7 @@ class SamplingIterator(IterableDataset):
                     valid_idcs = torch.tensor(
                         [i + num_offline for i in range(num_online) if trajs[i + num_offline]['is_valid']]).long()
                     # fetch the valid trajectories endpoints
-                    mols = [self.ctx.graph_to_mol(trajs[i]['traj'][-1][0]) for i in valid_idcs]
+                    mols = [self.ctx.graph_to_mol(trajs[i]['result']) for i in valid_idcs]
                     # ask the task to compute their reward
                     preds, m_is_valid = self.task.compute_flat_rewards(mols)
                     assert preds.ndim == 2, "FlatRewards should be (mbsize, n_objectives), even if n_objectives is 1"
@@ -214,12 +214,12 @@ class SamplingIterator(IterableDataset):
     def log_generated(self, trajs, log_rewards, flat_rewards, cond_info):
         if self.log_molecule_smis:
             mols = [
-                Chem.MolToSmiles(self.ctx.graph_to_mol(trajs[i]['traj'][-1][0])) if trajs[i]['is_valid'] else ''
+                Chem.MolToSmiles(self.ctx.graph_to_mol(trajs[i]['result'])) if trajs[i]['is_valid'] else ''
                 for i in range(len(trajs))
             ]
         else:
             mols = [
-                nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(t['traj'][-1][0], None, 'v') for t in trajs
+                nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(t['result'], None, 'v') for t in trajs
             ]
 
         flat_rewards = flat_rewards.reshape((len(flat_rewards), -1)).data.numpy().tolist()

--- a/src/gflownet/envs/graph_building_env.py
+++ b/src/gflownet/envs/graph_building_env.py
@@ -254,7 +254,9 @@ class GraphBuildingEnv:
         return parents
 
     def count_backward_transitions(self, g: Graph, check_idempotent: bool = False):
-        """Counts the number of parents of g without checking for isomorphisms"""
+        """Counts the number of parents of g (by default, without checking for isomorphisms)"""
+        # We can count actions backwards easily, but only if we don't check that they don't lead to
+        # the same parent. To do so, we need to enumerate (unique) parents and count how many there are:
         if check_idempotent:
             return len(self.parents(g))
         c = 0
@@ -617,6 +619,7 @@ class GraphActionCategorical:
 class GraphBuildingEnvContext:
     """A context class defines what the graphs are, how they map to and from data"""
     device: torch.device
+    action_mask_names: List[str]
 
     def aidx_to_GraphAction(self, g: gd.Data, action_idx: Tuple[int, int, int]) -> GraphAction:
         """Translate an action index (e.g. from a GraphActionCategorical) to a GraphAction

--- a/src/gflownet/envs/graph_building_env.py
+++ b/src/gflownet/envs/graph_building_env.py
@@ -203,7 +203,6 @@ class GraphBuildingEnv:
         parents: List[Pair(GraphAction, Graph)]
             The list of parent-action pairs that lead to `g`.
         """
-        raise ValueError('reimplement me with GraphAction!')  # also get rid of relabel...
         parents = []
         # Count node degrees
         degree = defaultdict(int)
@@ -227,9 +226,11 @@ class GraphBuildingEnv:
                 # the edge)
                 new_g = graph_without_edge(g, (a, b))
                 if nx.algorithms.is_connected(new_g):
-                    add_parent((self.add_edge, a, b), new_g)
+                    add_parent(GraphAction(GraphActionType.AddEdge, source=a, target=b), new_g)
             for k in g.edges[(a, b)]:
-                add_parent((self.set_edge_attr, (a, b), k, g.edges[(a, b)][k]), graph_without_edge_attr(g, (a, b), k))
+                add_parent(
+                    GraphAction(GraphActionType.SetEdgeAttr, source=a, target=b, attr=k, value=g.edges[(a, b)][k]),
+                    graph_without_edge_attr(g, (a, b), k))
 
         for i in g.nodes:
             # Can only remove leaf nodes and without attrs (except 'v'),
@@ -239,19 +240,23 @@ class GraphBuildingEnv:
                 if len(g.edges[edge]) == 0:
                     anchor = edge[0] if edge[1] == i else edge[1]
                     new_g = graph_without_node(g, i)
-                    add_parent((self.add_node, anchor, g.nodes[i]['v'], {'relabel': i}), new_g)
+                    add_parent(GraphAction(GraphActionType.AddNode, source=anchor, value=g.nodes[i]['v']), new_g)
             if len(g.nodes) == 1:
                 # The final node is degree 0, need this special case to remove it
                 # and end up with S0, the empty graph root
-                add_parent((self.add_node, None, g.nodes[i]['v'], {'relabel': i}), graph_without_node(g, i))
+                add_parent(GraphAction(GraphActionType.AddNode, source=0, value=g.nodes[i]['v']),
+                           graph_without_node(g, i))
             for k in g.nodes[i]:
                 if k == 'v':
                     continue
-                add_parent((self.set_node_attr, i, k, g.nodes[i][k]), graph_without_node_attr(g, i, k))
+                add_parent(GraphAction(GraphActionType.SetNodeAttr, source=i, attr=k, value=g.nodes[i][k]),
+                           graph_without_node_attr(g, i, k))
         return parents
 
-    def count_backward_transitions(self, g: Graph):
+    def count_backward_transitions(self, g: Graph, check_idempotent: bool = False):
         """Counts the number of parents of g without checking for isomorphisms"""
+        if check_idempotent:
+            return len(self.parents(g))
         c = 0
         deg = [g.degree[i] for i in range(len(g.nodes))]
         for a, b in g.edges:

--- a/src/gflownet/envs/graph_building_env.py
+++ b/src/gflownet/envs/graph_building_env.py
@@ -203,9 +203,9 @@ class GraphBuildingEnv:
         parents: List[Pair(GraphAction, Graph)]
             The list of parent-action pairs that lead to `g`.
         """
-        parents = []
+        parents: List[Tuple[GraphAction, Graph]] = []
         # Count node degrees
-        degree = defaultdict(int)
+        degree: Dict[int, int] = defaultdict(int)
         for a, b in g.edges:
             degree[a] += 1
             degree[b] += 1

--- a/src/gflownet/models/graph_transformer.py
+++ b/src/gflownet/models/graph_transformer.py
@@ -128,7 +128,7 @@ class GraphTransformerGFN(nn.Module):
     - SetEdgeAttr
 
     """
-    def __init__(self, env_ctx, num_emb=64, num_layers=3, num_heads=2, num_mlp_layers = 0):
+    def __init__(self, env_ctx, num_emb=64, num_layers=3, num_heads=2, num_mlp_layers=0):
         """See `GraphTransformer` for argument values"""
         super().__init__()
         self.transf = GraphTransformer(x_dim=env_ctx.num_node_dim, e_dim=env_ctx.num_edge_dim,

--- a/src/gflownet/models/graph_transformer.py
+++ b/src/gflownet/models/graph_transformer.py
@@ -128,7 +128,7 @@ class GraphTransformerGFN(nn.Module):
     - SetEdgeAttr
 
     """
-    def __init__(self, env_ctx, num_emb=64, num_layers=3, num_heads=2):
+    def __init__(self, env_ctx, num_emb=64, num_layers=3, num_heads=2, num_mlp_layers = 0):
         """See `GraphTransformer` for argument values"""
         super().__init__()
         self.transf = GraphTransformer(x_dim=env_ctx.num_node_dim, e_dim=env_ctx.num_edge_dim,
@@ -136,7 +136,6 @@ class GraphTransformerGFN(nn.Module):
                                        num_heads=num_heads)
         num_final = num_emb
         num_glob_final = num_emb * 2
-        num_mlp_layers = 0
         self.emb2add_edge = mlp(num_final, num_emb, 1, num_mlp_layers)
         self.emb2add_node = mlp(num_final, num_emb, env_ctx.num_new_node_values, num_mlp_layers)
         if env_ctx.num_node_attr_logits is not None:

--- a/src/gflownet/models/graph_transformer.py
+++ b/src/gflownet/models/graph_transformer.py
@@ -134,9 +134,9 @@ class GraphTransformerGFN(nn.Module):
         self.transf = GraphTransformer(x_dim=env_ctx.num_node_dim, e_dim=env_ctx.num_edge_dim,
                                        g_dim=env_ctx.num_cond_dim, num_emb=num_emb, num_layers=num_layers,
                                        num_heads=num_heads)
-        num_final = num_emb
-        num_glob_final = num_emb * 2
-        num_mlp_layers = 0
+        num_final = num_emb * 2
+        num_glob_final = num_emb ### * 2
+        num_mlp_layers = 2
         self.emb2add_edge = mlp(num_final, num_emb, 1, num_mlp_layers)
         self.emb2add_node = mlp(num_final, num_emb, env_ctx.num_new_node_values, num_mlp_layers)
         if env_ctx.num_node_attr_logits is not None:
@@ -147,6 +147,10 @@ class GraphTransformerGFN(nn.Module):
         self.emb2reward = mlp(num_glob_final, num_emb, 1, num_mlp_layers)
         self.logZ = mlp(env_ctx.num_cond_dim, num_emb * 2, 1, 2)
         self.action_type_order = env_ctx.action_type_order
+
+        ##############
+        self.gid2emb = mlp(17, 0, num_emb, 0)
+        self.nid2emb = mlp(4, 0, num_emb, 0)
 
         self._action_type_to_logit = {
             GraphActionType.Stop: (lambda emb, g: self.emb2stop(emb['graph'])),
@@ -170,19 +174,31 @@ class GraphTransformerGFN(nn.Module):
         return x * m + -1000 * (1 - m)
 
     def forward(self, g: gd.Batch, cond: torch.Tensor):
-        node_embeddings, graph_embeddings = self.transf(g, cond)
-        # "Non-edges" are edges not currently in the graph that we could add
+        graph_embeddings = self.gid2emb(g.gid)
+        F = self.emb2reward(graph_embeddings)
+        node_embeddings = torch.cat([graph_embeddings[g.batch], self.nid2emb(g.nodeidx)], 1)
         ne_row, ne_col = g.non_edge_index
         non_edge_embeddings = node_embeddings[ne_row] + node_embeddings[ne_col]
-        # On `::2`, edges are duplicated to make graphs undirected, only take the even ones
-        e_row, e_col = g.edge_index[:, ::2]
-        edge_embeddings = node_embeddings[e_row] + node_embeddings[e_col]
         emb = {
             'graph': graph_embeddings,
             'node': node_embeddings,
-            'edge': edge_embeddings,
             'non_edge': non_edge_embeddings,
         }
+
+        if 0:
+            node_embeddings, graph_embeddings = self.transf(g, cond)
+            # "Non-edges" are edges not currently in the graph that we could add
+            ne_row, ne_col = g.non_edge_index
+            non_edge_embeddings = node_embeddings[ne_row] + node_embeddings[ne_col]
+            # On `::2`, edges are duplicated to make graphs undirected, only take the even ones
+            e_row, e_col = g.edge_index[:, ::2]
+            edge_embeddings = node_embeddings[e_row] + node_embeddings[e_col]
+            emb = {
+                'graph': graph_embeddings,
+                'node': node_embeddings,
+                'edge': edge_embeddings,
+                'non_edge': non_edge_embeddings,
+            }
 
         cat = GraphActionCategorical(
             g,

--- a/src/gflownet/models/graph_transformer.py
+++ b/src/gflownet/models/graph_transformer.py
@@ -136,7 +136,7 @@ class GraphTransformerGFN(nn.Module):
                                        num_heads=num_heads)
         num_final = num_emb
         num_glob_final = num_emb * 2
-        num_mlp_layers = 2
+        num_mlp_layers = 0
         self.emb2add_edge = mlp(num_final, num_emb, 1, num_mlp_layers)
         self.emb2add_node = mlp(num_final, num_emb, env_ctx.num_new_node_values, num_mlp_layers)
         if env_ctx.num_node_attr_logits is not None:


### PR DESCRIPTION
Adds mechanisms to compensate for idempotent forward and backward actions ("different" actions that lead to the same state) and prevent under/overcounting transition probabilities.

Modifies:
- `GraphSampler` to optionally account for idempotent actions when counting backward transitions
- `TrajectoryBalance` to optionally account for idempotent actions when computing $P_F(s'|s)$ (i.e. actually computes $P_F(s'|s) = \sum_{a'\equiv a} P_F(a'|s)$ rather than just $P_F(a|s)$)
- `GraphBuildingEnv` to correctly enumerate parents of a state (taking into account isomorphic parents)

Also modifies `SamplingIterator` to rely on a clearer `'result'` key in trajectories rather than indexing.