### PR TITLE
Retire redundant fragment model

### DIFF
--- a/src/gflownet/tasks/seh_frag.py
+++ b/src/gflownet/tasks/seh_frag.py
@@ -16,7 +16,7 @@ from gflownet.algo.trajectory_balance import TrajectoryBalance
 from gflownet.envs.frag_mol_env import FragMolBuildingEnvContext
 from gflownet.envs.graph_building_env import GraphBuildingEnv
 from gflownet.models import bengio2021flow
-from gflownet.models.graph_transformer import GraphTransformerFragGFN
+from gflownet.models.graph_transformer import GraphTransformerGFN
 from gflownet.train import FlatRewards
 from gflownet.train import GFNTask
 from gflownet.train import GFNTrainer
@@ -119,7 +119,7 @@ class SEHFragTrainer(GFNTrainer):
                             ast.literal_eval(self.hps['temperature_dist_params']), wrap_model=self._wrap_model_mp)
 
     def setup_model(self):
-        self.model = GraphTransformerFragGFN(self.ctx, num_emb=self.hps['num_emb'], num_layers=self.hps['num_layers'])
+        self.model = GraphTransformerGFN(self.ctx, num_emb=self.hps['num_emb'], num_layers=self.hps['num_layers'])
 
     def setup(self):
         hps = self.hps

--- a/src/gflownet/tasks/seh_frag_moo.py
+++ b/src/gflownet/tasks/seh_frag_moo.py
@@ -20,7 +20,7 @@ from gflownet.algo.multiobjective_reinforce import MultiObjectiveReinforce
 from gflownet.algo.soft_q_learning import SoftQLearning
 from gflownet.algo.trajectory_balance import TrajectoryBalance
 from gflownet.models import bengio2021flow
-from gflownet.models.graph_transformer import GraphTransformerFragGFN
+from gflownet.models.graph_transformer import GraphTransformerGFN
 from gflownet.tasks.seh_frag import SEHFragTrainer
 from gflownet.train import FlatRewards
 from gflownet.train import GFNTask
@@ -166,7 +166,7 @@ class SEHMOOFragTrainer(SEHFragTrainer):
             model = GraphTransformerFragEnvelopeQL(self.ctx, num_emb=self.hps['num_emb'],
                                                    num_layers=self.hps['num_layers'], num_objectives=4)
         else:
-            model = GraphTransformerFragGFN(self.ctx, num_emb=self.hps['num_emb'], num_layers=self.hps['num_layers'])
+            model = GraphTransformerGFN(self.ctx, num_emb=self.hps['num_emb'], num_layers=self.hps['num_layers'])
 
         if self.hps['algo'] in ['A2C', 'MOQL']:
             model.do_mask = False
@@ -223,9 +223,9 @@ def main():
     """Example of how this model can be run outside of Determined"""
     hps = {
         'lr_decay': 10000,
-        'log_dir': '/scratch/logs/seh_frag_moo/run_tmp/',
+        'log_dir': '/scratch/emmanuel.bengio/logs/seh_frag_moo/run_tmp/',
         'num_training_steps': 20_000,
-        'validate_every': 5,
+        'validate_every': 500,
         'sampling_tau': 0.95,
         'num_layers': 6,
         'num_data_loader_workers': 12,


### PR DESCRIPTION
The current `GraphTransformerGFN` supports partial action spaces, there is thus no need for a specialized `GraphTransformerFragGFN` anymore. This PR replaces the latter with the more general class.