### PR TITLE
Add random walk features to atom-env

### DIFF
--- a/src/gflownet/models/bengio2021flow.py
+++ b/src/gflownet/models/bengio2021flow.py
@@ -72,7 +72,7 @@ def load_original_model():
     num_feat = (14 + 1 + NUM_ATOMIC_NUMBERS)
     mpnn = MPNNet(num_feat=num_feat, num_vec=0, dim=64, num_out_per_mol=1, num_out_per_stem=105, num_conv_steps=12)
     f = requests.get("https://github.com/GFNOrg/gflownet/raw/master/mols/data/pretrained_proxy/best_params.pkl.gz",
-                     stream=True)
+                     stream=True, timeout=30)
     params = pickle.load(gzip.open(f.raw))  # nosec
     param_map = {
         'lin0.weight': params[0],

--- a/src/gflownet/utils/graphs.py
+++ b/src/gflownet/utils/graphs.py
@@ -21,7 +21,7 @@ def random_walk_probs(g: Data, k: int, skip_odd=False):
     else:
         Pmult = P
     Pk = Pmult
-    for k in range(k):
+    for _ in range(k):
         diags.append(torch.diagonal(Pk, dim1=-2, dim2=-1))
         Pk = Pk @ Pmult
     p = torch.cat(diags, dim=0).transpose(0, 1)  # (num nodes, k)

--- a/src/gflownet/utils/graphs.py
+++ b/src/gflownet/utils/graphs.py
@@ -1,7 +1,7 @@
 import torch
-from torch_scatter import scatter_add
 from torch_geometric.data import Data
 from torch_geometric.utils import to_dense_adj
+from torch_scatter import scatter_add
 
 
 def random_walk_probs(g: Data, k: int, skip_odd=False):

--- a/src/gflownet/utils/graphs.py
+++ b/src/gflownet/utils/graphs.py
@@ -1,0 +1,28 @@
+import torch
+from torch_scatter import scatter_add
+from torch_geometric.data import Data
+from torch_geometric.utils import to_dense_adj
+
+
+def random_walk_probs(g: Data, k: int, skip_odd=False):
+    source, _ = g.edge_index[0], g.edge_index[1]
+    deg = scatter_add(torch.ones_like(source), source, dim=0, dim_size=g.num_nodes)
+    deg_inv = deg.pow(-1.)
+    deg_inv.masked_fill_(deg_inv == float('inf'), 0)
+
+    if g.edge_index.shape[1] == 0:
+        P = g.edge_index.new_zeros((1, g.num_nodes, g.num_nodes))
+    else:
+        # P = D^-1 * A
+        P = torch.diag(deg_inv) @ to_dense_adj(g.edge_index, max_num_nodes=g.num_nodes)  # (1, num nodes, num nodes)
+    diags = []
+    if skip_odd:
+        Pmult = P @ P
+    else:
+        Pmult = P
+    Pk = Pmult
+    for k in range(k):
+        diags.append(torch.diagonal(Pk, dim1=-2, dim2=-1))
+        Pk = Pk @ Pmult
+    p = torch.cat(diags, dim=0).transpose(0, 1)  # (num nodes, k)
+    return p


### PR DESCRIPTION
Adds:
- the ability compute random walk features of graph nodes, this is known to help GNNs' representational power (see [Dwivedi et al.](https://arxiv.org/abs/2110.07875)).
- these features by default to `MolBuildingEnvContext`, the atom environment context
- a docstring to `MolBuildingEnvContext.__init__`