### PR TITLE
Fix edge attributes in FragMolBuildingEnvContext

### DIFF
--- a/src/gflownet/envs/frag_mol_env.py
+++ b/src/gflownet/envs/frag_mol_env.py
@@ -54,8 +54,8 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
         self.num_new_node_values = len(self.frags_smi)
         self.num_node_attr_logits = 0
         self.num_node_dim = len(self.frags_smi) + 1
-        self.num_edge_attr_logits = (most_stems + 1) * 2
-        self.num_edge_dim = most_stems * 2
+        self.num_edge_attr_logits = most_stems * 2
+        self.num_edge_dim = (most_stems + 1) * 2
         self.num_cond_dim = num_cond_dim
         self.edges_are_duplicated = True
         self.edges_are_unordered = False
@@ -176,15 +176,14 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
         # atoms.
         for i, e in enumerate(g.edges):
             ad = g.edges[e]
-            a, b = e
-            for n, offset in zip(e, [0, self.num_stem_acts]):
+            for j, n in enumerate(e):
                 idx = ad.get(f'{int(n)}_attach', -1) + 1
-                edge_attr[i * 2, idx] = 1
-                edge_attr[i * 2 + 1, idx] = 1
+                edge_attr[i * 2, idx + (self.num_stem_acts + 1) * j] = 1
+                edge_attr[i * 2 + 1, idx + (self.num_stem_acts + 1) * (1 - j)] = 1
                 if f'{int(n)}_attach' not in ad:
                     for attach_point in range(max_degrees[n]):
                         if attach_point not in attached[n]:
-                            set_edge_attr_mask[i, offset + attach_point] = 1
+                            set_edge_attr_mask[i, attach_point + self.num_stem_acts * j] = 1
         edge_index = torch.tensor([e for i, j in g.edges for e in [(i, j), (j, i)]], dtype=torch.long).reshape(
             (-1, 2)).T
         if x.shape[0] == self.max_frags:


### PR DESCRIPTION
Resolves #58 following @bengioe's suggestion 

Changes:
- change `num_edge_dim` to `(most_stems + 1) * 2` since one-hot features encode `most_stems + 1` options (no attribute, or one of at most `most_stems` attributes) per node
- fill `edge_attr` using proper offsets
- change `num_edge_attr_logits` to `most_stems * 2` since `set_edge_attr_mask` values at positions `>= 2 * most_stems` are always set to zero (`attach_point + self.num_stem_acts < most_stems * 2`)