### PR TITLE
chore: relock dependencies

### DIFF
--- a/requirements/dev_3.9.txt
+++ b/requirements/dev_3.9.txt
@@ -2,7 +2,7 @@
 
 absl-py==1.4.0
     # via tensorboard
-bandit==1.7.5
+bandit[toml]==1.7.5
     # via -r requirements/dev.in
 black==23.3.0
     # via -r requirements/dev.in
@@ -25,7 +25,7 @@ click==8.1.3
     #   black
     #   pip-compile-multi
     #   pip-tools
-coverage==7.2.3
+coverage[toml]==7.2.5
     # via pytest-cov
 cvxopt==1.3.0
     # via -r requirements/main.in
@@ -57,11 +57,11 @@ gpytorch==1.8.1
     #   botorch
 grpcio==1.54.0
     # via tensorboard
-identify==2.5.22
+identify==2.5.23
     # via pre-commit
 idna==3.4
     # via requests
-importlib-metadata==6.5.0
+importlib-metadata==6.6.0
     # via
     #   markdown
     #   typeguard
@@ -103,7 +103,7 @@ nodeenv==1.7.0
     # via pre-commit
 numexpr==2.8.4
     # via tables
-numpy==1.24.2
+numpy==1.24.3
     # via
     #   gpytorch
     #   numexpr
@@ -127,7 +127,7 @@ packaging==23.1
     #   build
     #   pytest
     #   tables
-pandas==2.0.0
+pandas==2.0.1
     # via torch-geometric
 pathspec==0.11.1
     # via black
@@ -139,7 +139,7 @@ pip-compile-multi==2.6.2
     # via -r requirements/dev.in
 pip-tools==6.13.0
     # via pip-compile-multi
-platformdirs==3.2.0
+platformdirs==3.5.0
     # via
     #   black
     #   virtualenv
@@ -193,18 +193,18 @@ rdflib==6.3.2
     # via torch-geometric
 rdkit==2022.9.5
     # via -r requirements/main.in
-requests==2.28.2
+requests==2.29.0
     # via
     #   requests-oauthlib
     #   tensorboard
     #   torch-geometric
 requests-oauthlib==1.3.1
     # via google-auth-oauthlib
-rich==13.3.4
+rich==13.3.5
     # via bandit
 rsa==4.9
     # via google-auth
-ruff==0.0.262
+ruff==0.0.263
     # via -r requirements/dev.in
 scikit-learn==1.2.2
     # via
@@ -280,9 +280,9 @@ tzdata==2023.3
     # via pandas
 urllib3==1.26.15
     # via requests
-virtualenv==20.22.0
+virtualenv==20.23.0
     # via pre-commit
-werkzeug==2.2.3
+werkzeug==2.3.2
     # via tensorboard
 wheel==0.40.0
     # via

--- a/requirements/main_3.9.txt
+++ b/requirements/main_3.9.txt
@@ -10,17 +10,17 @@ cachetools==5.3.0
     # via google-auth
 certifi==2022.12.7
     # via requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 cvxopt==1.3.0
     # via -r requirements/main.in
-cython==0.29.33
+cython==0.29.34
     # via tables
-google-auth==2.16.0
+google-auth==2.17.3
     # via
     #   google-auth-oauthlib
     #   tensorboard
-google-auth-oauthlib==0.4.6
+google-auth-oauthlib==1.0.0
     # via tensorboard
 googledrivedownloader==0.4
     # via torch-geometric
@@ -28,11 +28,11 @@ gpytorch==1.8.1
     # via
     #   -r requirements/main.in
     #   botorch
-grpcio==1.51.1
+grpcio==1.54.0
     # via tensorboard
 idna==3.4
     # via requests
-importlib-metadata==6.0.0
+importlib-metadata==6.6.0
     # via markdown
 isodate==0.6.1
     # via rdflib
@@ -40,23 +40,23 @@ jinja2==3.1.2
     # via torch-geometric
 joblib==1.2.0
     # via scikit-learn
-markdown==3.4.1
+markdown==3.4.3
     # via tensorboard
 markupsafe==2.1.2
     # via
     #   jinja2
     #   werkzeug
-msgpack==1.0.4
+msgpack==1.0.5
     # via blosc2
 multipledispatch==0.6.0
     # via botorch
-networkx==3.0
+networkx==3.1
     # via
     #   -r requirements/main.in
     #   torch-geometric
 numexpr==2.8.4
     # via tables
-numpy==1.24.1
+numpy==1.24.3
     # via
     #   gpytorch
     #   numexpr
@@ -74,23 +74,23 @@ oauthlib==3.2.2
     # via requests-oauthlib
 opt-einsum==3.3.0
     # via pyro-ppl
-packaging==23.0
+packaging==23.1
     # via tables
-pandas==1.5.3
+pandas==2.0.1
     # via torch-geometric
-pillow==9.4.0
+pillow==9.5.0
     # via rdkit
-protobuf==3.20.3
+protobuf==4.22.3
     # via tensorboard
 py-cpuinfo==9.0.0
     # via tables
 pyarrow==11.0.0
     # via -r requirements/main.in
-pyasn1==0.4.8
+pyasn1==0.5.0
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.2.8
+pyasn1-modules==0.3.0
     # via google-auth
 pyparsing==3.0.9
     # via
@@ -104,17 +104,17 @@ pyro-ppl==1.8.0
     #   botorch
 python-dateutil==2.8.2
     # via pandas
-pytz==2022.7.1
+pytz==2023.3
     # via pandas
 pyyaml==6.0
     # via
     #   torch-geometric
     #   yacs
-rdflib==6.2.0
+rdflib==6.3.2
     # via torch-geometric
-rdkit==2022.9.4
+rdkit==2022.9.5
     # via -r requirements/main.in
-requests==2.28.2
+requests==2.29.0
     # via
     #   requests-oauthlib
     #   tensorboard
@@ -123,11 +123,11 @@ requests-oauthlib==1.3.1
     # via google-auth-oauthlib
 rsa==4.9
     # via google-auth
-scikit-learn==1.2.1
+scikit-learn==1.2.2
     # via
     #   gpytorch
     #   torch-geometric
-scipy==1.10.0
+scipy==1.10.1
     # via
     #   -r requirements/main.in
     #   botorch
@@ -143,9 +143,9 @@ six==1.16.0
     #   python-dateutil
 tables==3.8.0
     # via -r requirements/main.in
-tensorboard==2.11.2
+tensorboard==2.12.2
     # via -r requirements/main.in
-tensorboard-data-server==0.6.1
+tensorboard-data-server==0.7.0
     # via tensorboard
 tensorboard-plugin-wit==1.8.1
     # via tensorboard
@@ -165,21 +165,23 @@ torch-scatter==2.0.9
     # via -r requirements/main.in
 torch-sparse==0.6.13
     # via -r requirements/main.in
-tqdm==4.64.1
+tqdm==4.65.0
     # via
     #   pyro-ppl
     #   torch-geometric
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via torch
-urllib3==1.26.14
+tzdata==2023.3
+    # via pandas
+urllib3==1.26.15
     # via requests
-werkzeug==2.2.3
+werkzeug==2.3.2
     # via tensorboard
-wheel==0.38.4
+wheel==0.40.0
     # via tensorboard
 yacs==0.1.8
     # via torch-geometric
-zipp==3.12.0
+zipp==3.15.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
# What?
lock dependencies
# Why?
Monthly maintenace
# Notes:
```

python
	 version: 3.9.14
	location: /usr/local/bin/python
roadie
	 version: 6.4.1
	location: /usr/local/lib/python3.9/site-packages/roadie
✓ Retrieving roadie-enabled Python interpreters
Found roadie for the following Python versions: 3.7, 3.8, 3.9, 3.10, 3.11
✓ Attempting to lock for Python 3.9
✗ Attempting to lock for Python 3.11
Failed to lock Python 3.11 using /root/.pyenv/versions/3.11.0/bin/roadie:
/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/yaspin/core.py:59: UserWarning: color, on_color and attrs are not supported when running in jupyter
	  self._color = self._set_color(color) if color else color
	python
		 version: 3.11.0
		location: /root/.pyenv/versions/3.11.0/bin/python3.11
	roadie
		 version: 6.4.1
		location: /root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/roadie
✓ Sorting Requirements
✗ Generating lock file for requirements/dev.in
		  ERROR: Could not find a version that satisfies the requirement torch==1.10.2 (from -r /codefresh/volume/projects/recursionpharma/gflownet/requirements/main.in (line 3)) (from versions: 1.13.0, 1.13.1, 2.0.0)
		Traceback (most recent call last):
		  File "/root/.pyenv/versions/3.11.0/bin/pip-compile", line 8, in <module>
		    sys.exit(cli())
		             ^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
		    return self.main(*args, **kwargs)
		           ^^^^^^^^^^^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/click/core.py", line 1055, in main
		    rv = self.invoke(ctx)
		         ^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
		    return ctx.invoke(self.callback, **ctx.params)
		           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/click/core.py", line 760, in invoke
		    return __callback(*args, **kwargs)
		           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/click/decorators.py", line 26, in new_func
		    return f(get_current_context(), *args, **kwargs)
		           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/piptools/scripts/compile.py", line 510, in cli
		    results = resolver.resolve(max_rounds=max_rounds)
		              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/piptools/resolver.py", line 260, in resolve
		    has_changed, best_matches = self._resolve_one_round()
		                                ^^^^^^^^^^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/piptools/resolver.py", line 350, in _resolve_one_round
		    their_constraints.extend(self._iter_dependencies(best_match))
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/piptools/resolver.py", line 463, in _iter_dependencies
		    dependencies = self.repository.get_dependencies(ireq)
		                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/piptools/repositories/pypi.py", line 250, in get_dependencies
		    self._dependencies_cache[ireq] = self.resolve_reqs(
		                                     ^^^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/piptools/repositories/pypi.py", line 213, in resolve_reqs
		    results = resolver._resolve_one(reqset, ireq)
		              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/pip/_internal/resolution/legacy/resolver.py", line 509, in _resolve_one
		    dist = self._get_dist_for(req_to_install)
		           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/pip/_internal/resolution/legacy/resolver.py", line 461, in _get_dist_for
		    self._populate_link(req)
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/pip/_internal/resolution/legacy/resolver.py", line 422, in _populate_link
		    req.link = self._find_requirement_link(req)
		               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/pip/_internal/resolution/legacy/resolver.py", line 388, in _find_requirement_link
		    best_candidate = self.finder.find_requirement(req, upgrade)
		                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
		  File "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/pip/_internal/index/package_finder.py", line 941, in find_requirement
		    raise DistributionNotFound(
		pip._internal.exceptions.DistributionNotFound: No matching distribution found for torch==1.10.2 (from -r /codefresh/volume/projects/recursionpharma/gflownet/requirements/main.in (line 3))
		
	Some equipment was damaged when loading the bus check logs above for more information.
	Do not forget to commit generated files and review warnings and errors
	
✗ Attempting to lock for Python 3.10
Failed to lock Python 3.10 using /root/.pyenv/versions/3.10.7/bin/roadie:
/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/yaspin/core.py:59: UserWarning: color, on_color and attrs are not supported when running in jupyter
	  self._color = self._set_color(color) if color else color
	python
		 version: 3.10.7
		location: /root/.pyenv/versions/3.10.7/bin/python3.10
	roadie
		 version: 6.4.1
		location: /root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/roadie
✓ Sorting Requirements
✗ Generating lock file for requirements/dev.in
		    error: subprocess-exited-with-error
		    × python setup.py egg_info did not run successfully.
		    │ exit code: 1
		    ╰─> [6 lines of output]
		        Traceback (most recent call last):
		          File "<string>", line 2, in <module>
		          File "<pip-setuptools-caller>", line 34, in <module>
		          File "/tmp/pip-resolver-iehjy5zq/torch-sparse/setup.py", line 8, in <module>
		            import torch
		        ModuleNotFoundError: No module named 'torch'
		        [end of output]
		    note: This error originates from a subprocess, and is likely not a problem with pip.
		Traceback (most recent call last):
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/operations/build/metadata_legacy.py", line 64, in generate_metadata
		    call_subprocess(
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/utils/subprocess.py", line 224, in call_subprocess
		    raise error
		pip._internal.exceptions.InstallationSubprocessError: python setup.py egg_info exited with 1
		The above exception was the direct cause of the following exception:
		Traceback (most recent call last):
		  File "/root/.pyenv/versions/3.10.7/bin/pip-compile", line 8, in <module>
		    sys.exit(cli())
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
		    return self.main(*args, **kwargs)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/click/core.py", line 1055, in main
		    rv = self.invoke(ctx)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
		    return ctx.invoke(self.callback, **ctx.params)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/click/core.py", line 760, in invoke
		    return __callback(*args, **kwargs)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
		    return f(get_current_context(), *args, **kwargs)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/piptools/scripts/compile.py", line 510, in cli
		    results = resolver.resolve(max_rounds=max_rounds)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/piptools/resolver.py", line 260, in resolve
		    has_changed, best_matches = self._resolve_one_round()
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/piptools/resolver.py", line 350, in _resolve_one_round
		    their_constraints.extend(self._iter_dependencies(best_match))
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/piptools/resolver.py", line 463, in _iter_dependencies
		    dependencies = self.repository.get_dependencies(ireq)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/piptools/repositories/pypi.py", line 250, in get_dependencies
		    self._dependencies_cache[ireq] = self.resolve_reqs(
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/piptools/repositories/pypi.py", line 213, in resolve_reqs
		    results = resolver._resolve_one(reqset, ireq)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/resolution/legacy/resolver.py", line 509, in _resolve_one
		    dist = self._get_dist_for(req_to_install)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/resolution/legacy/resolver.py", line 462, in _get_dist_for
		    dist = self.preparer.prepare_linked_requirement(req)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 491, in prepare_linked_requirement
		    return self._prepare_linked_requirement(req, parallel_builds)
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 577, in _prepare_linked_requirement
		    dist = _get_prepared_distribution(
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 69, in _get_prepared_distribution
		    abstract_dist.prepare_distribution_metadata(
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/distributions/sdist.py", line 61, in prepare_distribution_metadata
		    self.req.prepare_metadata()
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/req/req_install.py", line 541, in prepare_metadata
		    self.metadata_directory = generate_metadata_legacy(
		  File "/root/.pyenv/versions/3.10.7/lib/python3.10/site-packages/pip/_internal/operations/build/metadata_legacy.py", line 71, in generate_metadata
		    raise MetadataGenerationFailed(package_details=details) from error
		pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
		
	Some equipment was damaged when loading the bus check logs above for more information.
	Do not forget to commit generated files and review warnings and errors
	
Skipping Python 3.7
✓ Attempting to lock for Python 3.8

```