### PR TITLE
Add thermometer encoding for the preference vector

### DIFF
--- a/src/gflownet/tasks/seh_frag_moo.py
+++ b/src/gflownet/tasks/seh_frag_moo.py
@@ -175,7 +175,7 @@ class SEHMOOFragTrainer(SEHFragTrainer):
             "n_valid_prefs": 15,
             "n_valid_repeats_per_pref": 128,
             "preference_type": "dirichlet",
-            "use_pref_thermometer": True,
+            "use_pref_thermometer": False,
         }
 
     def setup_algo(self):

--- a/src/gflownet/tasks/seh_frag_moo.py
+++ b/src/gflownet/tasks/seh_frag_moo.py
@@ -26,8 +26,8 @@ from gflownet.models.graph_transformer import GraphTransformerGFN
 from gflownet.tasks.seh_frag import SEHFragTrainer, SEHTask
 from gflownet.train import FlatRewards, RewardScalar
 from gflownet.utils import metrics, sascore
-from gflownet.utils.transforms import thermometer
 from gflownet.utils.multiobjective_hooks import MultiObjectiveStatsHook, TopKHook
+from gflownet.utils.transforms import thermometer
 
 
 class SEHMOOTask(SEHTask):


### PR DESCRIPTION
Adds the option to use thermometer encoding for the preference vector in `seh_frag_moo`, makes this option the default (due to apparent increased performance, plots to come). Preferences were previously just encoded as their `[0,1]` value.

Side fix: Removes redundant creation of `self.task` in `seh_frag_moo`.