### PR TITLE
Add special case for nitrogen valence

### DIFF
--- a/src/gflownet/envs/mol_building_env.py
+++ b/src/gflownet/envs/mol_building_env.py
@@ -112,7 +112,7 @@ class MolBuildingEnvContext(GraphBuildingEnvContext):
         pt = Chem.GetPeriodicTable()
         self._max_atom_valence = {
             **{a: max(pt.GetValenceList(a)) for a in atoms},
-            "N": 5,  # allow nitro groups by allowing the 5-valent N (perhaps there's a better way?)
+            "N": 3,  # We'll handle nitrogen valence later explicitly in graph_to_Data
             "*": 0,  # wildcard atoms have 0 valence until filled in
         }
 
@@ -219,6 +219,12 @@ class MolBuildingEnvContext(GraphBuildingEnvContext):
                     set_node_attr_mask[i, s:e] = 0
             # Account for charge and explicit Hs in atom as limiting the total valence
             max_atom_valence = self._max_atom_valence[ad.get("fill_wildcard", None) or ad["v"]]
+            # Special rule for Nitrogen
+            if ad["v"] == "N" and ad.get("charge", 0) == 1:
+                # This is definitely a heuristic, but to keep things simple we'll limit Nitrogen's valence to 3 (as
+                # per self._max_atom_valence) unless it is charged, then we make it 5.
+                # This keeps RDKit happy (and is probably a good idea anyway).
+                max_atom_valence = 5
             max_valence[n] = max_atom_valence - abs(ad.get("charge", 0)) - ad.get("expl_H", 0)
             # Compute explicitly defined valence:
             explicit_valence[n] = 0


### PR DESCRIPTION
This PR corrects the max valence of nitrogen, and prevents the agent from forming too many bonds with it(that would induce a molecule considered invalid by RDKit).

The fix is definitely a heuristic, but it is compatible with the nitrogen bond variety found in ChembL. Consider the following snippet:
```python
import pandas as pd
import tqdm
import multiprocessing
from rdkit import Chem
from gflownet.envs.mol_building_env import MolBuildingEnvContext

chembl = pd.read_parquet('path/to/chembl.parquet')
ctx = MolBuildingEnvContext(['Br', 'C', 'Cl', 'F', 'N', 'O', 'P', 'S'])

def f(smi):
    mol = Chem.MolFromSmiles(smi)
    if mol is None:
        return []
    g = ctx.obj_to_graph(mol)
    bts = []
    for i in g.nodes:
        if g.nodes[i]['v'] == 'N':
            ns = [g.edges[(i, u)] for u in g.neighbors(i)]
            bt = (len(ns),
                  tuple(sorted([b.get('type',Chem.BondType.SINGLE).real for b in ns])),
                  g.nodes[i].get('charge', 0),
                  g.nodes[i].get('no_impl', 0))
            bts.append(bt)
    return bts

def g():
    bonds = []
    with multiprocessing.Pool(64) as pool:
        for i in tqdm.tqdm(pool.imap_unordered(f, chembl.index), total=len(chembl)):
            bonds += i
    print(set(bonds))
            
if __name__ == '__main__':
    g()
```

which outputs:
```python
{(0, (), 0, 0),
 (1, (1,), 0, 0),
 (1, (2,), -1, 0),
 (1, (2,), -1, True),
 (1, (2,), 0, 0),
 (1, (3,), 0, 0),
 (2, (1, 1), -1, True),
 (2, (1, 1), 0, 0),
 (2, (1, 1), 0, True),
 (2, (1, 2), 0, 0),
 (2, (1, 2), 0, True),
 (2, (1, 3), 1, True),
 (2, (2, 2), 1, 0),
 (2, (2, 2), 1, True),
 (3, (1, 1, 1), 0, 0),
 (3, (1, 1, 1), 0, True),
 (3, (1, 1, 1), 1, True),
 (3, (1, 1, 2), 1, 0),
 (3, (1, 1, 2), 1, True),
 (4, (1, 1, 1, 1), 1, 0),
 (4, (1, 1, 1, 1), 1, True)}
```

Seeing this suggested the following heuristic to me: limit Nitrogen's valence to 3 unless it is charged, in which case we make it 5. The positive charge reduces the maximum number of bonds to 4, which is compatible with the above.