### PR TITLE
Make PRs trigger github workflows

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,5 +1,9 @@
 name: Build-and-Test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - trunk
+  pull_request:
 jobs:
   tests:
     name: ${{ matrix.name }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,5 +1,5 @@
 name: Build-and-Test
-on: [push]
+on: [push, pull_request]
 jobs:
   tests:
     name: ${{ matrix.name }}

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,5 +1,5 @@
 name: Code Quality
-on: [push]
+on: [push, pull_request]
 jobs:
   tests:
     name: Code Quality

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,5 +1,9 @@
 name: Code Quality
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - trunk
+  pull_request:
 jobs:
   tests:
     name: Code Quality


### PR DESCRIPTION
This change should make it possible for external pull requests to [trigger our github workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull-request-events-for-forked-repositories).

It seems like we may still need to [trigger them manually](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks) for Recursion-external forks, which sounds like a good thing, but at least it will be possible.