### PR TITLE
add faster subTB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Model cache
+src/gflownet/models/cache/
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/gflownet/algo/config.py
+++ b/src/gflownet/algo/config.py
@@ -37,6 +37,7 @@ class TBConfig:
     subtb_max_len: int = 128
     Z_learning_rate: float = 1e-4
     Z_lr_decay: float = 50_000
+    cum_subtb: bool = True
 
 
 @dataclass

--- a/tests/test_subtb.py
+++ b/tests/test_subtb.py
@@ -1,0 +1,29 @@
+from functools import reduce
+
+import torch
+
+from gflownet.algo.trajectory_balance import subTB
+
+
+def subTB_ref(P_F, P_B, F):
+    h = F.shape[0] - 1
+    assert P_F.shape == P_B.shape == (h,)
+    assert F.ndim == 1
+
+    dtype = reduce(torch.promote_types, [P_F.dtype, P_B.dtype, F.dtype])
+    D = torch.zeros(h, h, dtype=dtype)
+    for i in range(h):
+        for j in range(i, h):
+            D[i, j] = F[i] - F[j + 1]
+            D[i, j] = D[i, j] + P_F[i : j + 1].sum()
+            D[i, j] = D[i, j] - P_B[i : j + 1].sum()
+    return D
+
+
+def test_subTB():
+    for T in range(5, 20):
+        T = 10
+        P_F = torch.randint(1, 10, (T,))
+        P_B = torch.randint(1, 10, (T,))
+        F = torch.randint(1, 10, (T + 1,))
+        assert (subTB(F, P_F - P_B) == subTB_ref(P_F, P_B, F)).all()


### PR DESCRIPTION
```
self.subtb_loss_fast(log_p_F, log_p_B, log_F_preds, clip_log_R, batch.traj_lens)
  Median: 59.95 ms
  IQR:    0.29 ms (59.84 to 60.13)
  17 measurements, 1 runs per measurement, 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7f89941df130>
self.subtb_cum(log_p_F, log_p_B, log_F_preds, clip_log_R, batch.traj_lens)
  Median: 16.43 ms
  IQR:    0.12 ms (16.41 to 16.53)
  7 measurements, 10 runs per measurement, 1 thread
```

![image](https://github.com/recursionpharma/gflownet/assets/2301159/f8d5b8b0-61f1-4a52-a5c2-ad99a1f4dc1a)

subtb_diff is the mse of the loss between the two implementations.

Diff is not zero because I precompute `P_F - P_B`, doing `cross(P_F) - cross(P_B)` instead of `cross(P_F - P_B)` yields the exact same results.