### PR TITLE
Adding detailed balance

### DIFF
--- a/src/gflownet/algo/config.py
+++ b/src/gflownet/algo/config.py
@@ -1,5 +1,12 @@
 from dataclasses import dataclass
 from typing import Optional
+from enum import Enum
+
+
+class TBVariant(Enum):
+    TB = 0
+    SubTB1 = 1
+    DB = 2
 
 
 @dataclass
@@ -20,6 +27,8 @@ class TBConfig:
         Whether to correct for idempotent actions
     do_parameterize_p_b : bool
         Whether to parameterize the P_B distribution (otherwise it is uniform)
+    do_length_normalize : bool
+        Whether to normalize the loss by the length of the trajectory
     subtb_max_len : int
         The maximum length trajectories, used to cache subTB computation indices
     Z_learning_rate : float
@@ -31,9 +40,10 @@ class TBConfig:
     bootstrap_own_reward: bool = False
     epsilon: Optional[float] = None
     reward_loss_multiplier: float = 1.0
-    do_subtb: bool = False
+    variant: TBVariant = TBVariant.TB
     do_correct_idempotent: bool = False
     do_parameterize_p_b: bool = False
+    do_length_normalize: bool = False
     subtb_max_len: int = 128
     Z_learning_rate: float = 1e-4
     Z_lr_decay: float = 50_000

--- a/src/gflownet/algo/config.py
+++ b/src/gflownet/algo/config.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from typing import Optional
 from enum import Enum
+from typing import Optional
 
 
 class TBVariant(Enum):

--- a/src/gflownet/algo/config.py
+++ b/src/gflownet/algo/config.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 
 class TBVariant(Enum):
+    """See algo.trajectory_balance.TrajectoryBalance for details."""
+
     TB = 0
     SubTB1 = 1
     DB = 2
@@ -21,8 +23,8 @@ class TBConfig:
         The epsilon parameter in log-flow smoothing (see paper)
     reward_loss_multiplier : float
         The multiplier for the reward loss when bootstrapping the reward. (deprecated)
-    do_subtb : bool
-        Whether to use the full N^2 subTB loss
+    variant : TBVariant
+        The loss variant. See algo.trajectory_balance.TrajectoryBalance for details.
     do_correct_idempotent : bool
         Whether to correct for idempotent actions
     do_parameterize_p_b : bool

--- a/src/gflownet/algo/trajectory_balance.py
+++ b/src/gflownet/algo/trajectory_balance.py
@@ -66,10 +66,23 @@ class TrajectoryBalanceModel(nn.Module):
 
 
 class TrajectoryBalance(GFNAlgorithm):
-    """TB implementation, see
-    "Trajectory Balance: Improved Credit Assignment in GFlowNets Nikolay Malkin, Moksh Jain,
-    Emmanuel Bengio, Chen Sun, Yoshua Bengio"
-    https://arxiv.org/abs/2201.13259"""
+    """Trajectory-based GFN loss implementations. Implements
+    - TB: Trajectory Balance: Improved Credit Assignment in GFlowNets Nikolay Malkin, Moksh Jain,
+    Emmanuel Bengio, Chen Sun, Yoshua Bengio
+    https://arxiv.org/abs/2201.13259
+
+    - SubTB(1): Learning GFlowNets from partial episodes for improved convergence and stability, Kanika Madan, Jarrid
+    Rector-Brooks, Maksym Korablyov, Emmanuel Bengio, Moksh Jain, Andrei Cristian Nica, Tom Bosc, Yoshua Bengio,
+    Nikolay Malkin
+    https://arxiv.org/abs/2209.12782
+    Note: We implement the lambda=1 version of SubTB here (this choice is based on empirical results from the paper)
+
+    - DB: GFlowNet Foundations, Yoshua Bengio, Salem Lahlou, Tristan Deleu, Edward J. Hu, Mo Tiwari, Emmanuel Bengio
+    https://arxiv.org/abs/2111.09266
+    Note: This is the trajectory version of Detailed Balance (i.e. transitions are not iid, but trajectories are).
+    Empirical results in subsequent papers suggest that DB may be improved by training on iid transitions (sampled from
+    a replay buffer) instead of trajectories.
+    """
 
     def __init__(
         self,
@@ -78,10 +91,7 @@ class TrajectoryBalance(GFNAlgorithm):
         rng: np.random.RandomState,
         cfg: Config,
     ):
-        """TB implementation, see
-        "Trajectory Balance: Improved Credit Assignment in GFlowNets Nikolay Malkin, Moksh Jain,
-        Emmanuel Bengio, Chen Sun, Yoshua Bengio"
-        https://arxiv.org/abs/2201.13259
+        """Instanciate a TB algorithm.
 
         Parameters
         ----------

--- a/src/gflownet/algo/trajectory_balance.py
+++ b/src/gflownet/algo/trajectory_balance.py
@@ -8,9 +8,9 @@ import torch_geometric.data as gd
 from torch import Tensor
 from torch_scatter import scatter, scatter_sum
 
+from gflownet.algo.config import TBVariant
 from gflownet.algo.graph_sampling import GraphSampler
 from gflownet.config import Config
-from gflownet.algo.config import TBVariant
 from gflownet.envs.graph_building_env import (
     Graph,
     GraphAction,

--- a/src/gflownet/tasks/seh_frag.py
+++ b/src/gflownet/tasks/seh_frag.py
@@ -128,11 +128,11 @@ def main():
         "device": "cuda" if torch.cuda.is_available() else "cpu",
         "overwrite_existing_exp": True,
         "num_training_steps": 10_000,
-        "num_workers": 0,
+        "num_workers": 8,
         "opt": {
             "lr_decay": 20000,
         },
-        "algo": {"sampling_tau": 0.99, "tb": {"variant": "DB", "do_parameterize_p_b": True}},
+        "algo": {"sampling_tau": 0.99},
         "cond": {
             "temperature": {
                 "sample_dist": "uniform",

--- a/src/gflownet/tasks/seh_frag.py
+++ b/src/gflownet/tasks/seh_frag.py
@@ -125,16 +125,14 @@ def main():
     """Example of how this model can be run outside of Determined"""
     hps = {
         "log_dir": "./logs/debug_run_seh_frag",
-        "device": torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu"),
+        "device": "cuda" if torch.cuda.is_available() else "cpu",
         "overwrite_existing_exp": True,
         "num_training_steps": 10_000,
-        "num_workers": 8,
+        "num_workers": 0,
         "opt": {
             "lr_decay": 20000,
         },
-        "algo": {
-            "sampling_tau": 0.99,
-        },
+        "algo": {"sampling_tau": 0.99, "tb": {"variant": "DB", "do_parameterize_p_b": True}},
         "cond": {
             "temperature": {
                 "sample_dist": "uniform",

--- a/src/gflownet/tasks/seh_frag_moo.py
+++ b/src/gflownet/tasks/seh_frag_moo.py
@@ -358,7 +358,7 @@ def main():
     """Example of how this model can be run."""
     hps = {
         "log_dir": "./logs/debug_run_sfm",
-        "device": torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu"),
+        "device": "cuda" if torch.cuda.is_available() else "cpu",
         "pickle_mp_messages": True,
         "overwrite_existing_exp": True,
         "seed": 0,


### PR DESCRIPTION
Short PR, since DB is extremely close to TB/SubTB, which adds the detailed balance (first proposed in [1]).

This also:
- makes the used variant (TB/SubTB/DB) an Enum
- makes `do_length_normalize` a proper flag since it seems potentially important for DB
- Fixes the incorrect default `device` flag in some scripts

Experiments are still running to check that everything is ok.

[1] Bengio, Y., Lahlou, S., Deleu, T., Hu, E., Tiwari, M., and Bengio, E.; GFlowNet foundations