### PR TITLE
Support for LR sequence environments

### DIFF
--- a/src/gflownet/algo/trajectory_balance.py
+++ b/src/gflownet/algo/trajectory_balance.py
@@ -109,6 +109,9 @@ class TrajectoryBalance(GFNAlgorithm):
         self.reward_normalize_losses = False
         self.sample_temp = 1
         self.bootstrap_own_reward = self.cfg.bootstrap_own_reward
+        # When the model is autoregressive, we can avoid giving it ["A", "AB", "ABC", ...] as a sequence of inputs, and
+        # instead give "ABC...Z" as a single input, but grab the logits at every timestep. Only works if using something
+        # like a transformer with causal self-attention.
         self.model_is_autoregressive = False
 
         self.graph_sampler = GraphSampler(

--- a/src/gflownet/data/sampling_iterator.py
+++ b/src/gflownet/data/sampling_iterator.py
@@ -4,11 +4,10 @@ from collections.abc import Iterable
 from copy import deepcopy
 from typing import Callable, List
 
-import networkx as nx
 import numpy as np
 import torch
 import torch.nn as nn
-from rdkit import Chem, RDLogger
+from rdkit import RDLogger
 from torch.utils.data import Dataset, IterableDataset
 
 from gflownet.data.replay_buffer import ReplayBuffer
@@ -222,7 +221,6 @@ class SamplingIterator(IterableDataset):
                     ), "FlatRewards should be (mbsize, n_objectives), even if n_objectives is 1"
                     # The task may decide some of the mols are invalid, we have to again filter those
                     valid_idcs = valid_idcs[m_is_valid]
-                    valid_mols = [m for m, v in zip(mols, m_is_valid) if v]
                     pred_reward = torch.zeros((num_online, online_flat_rew.shape[1]))
                     pred_reward[valid_idcs - num_offline] = online_flat_rew
                     is_valid[num_offline:] = False

--- a/src/gflownet/envs/frag_mol_env.py
+++ b/src/gflownet/envs/frag_mol_env.py
@@ -331,3 +331,7 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
         if mol is None:
             return False
         return True
+
+    def object_to_log_repr(self, g: Graph):
+        """Convert a Graph to a string representation"""
+        return Chem.MolToSmiles(self.graph_to_mol(g))

--- a/src/gflownet/envs/graph_building_env.py
+++ b/src/gflownet/envs/graph_building_env.py
@@ -781,6 +781,7 @@ class GraphBuildingEnvContext:
     """A context class defines what the graphs are, how they map to and from data"""
 
     device: torch.device
+    action_type_order: List[GraphActionType]
 
     def aidx_to_GraphAction(self, g: gd.Data, action_idx: Tuple[int, int, int], fwd: bool = True) -> GraphAction:
         """Translate an action index (e.g. from a GraphActionCategorical) to a GraphAction

--- a/src/gflownet/envs/graph_building_env.py
+++ b/src/gflownet/envs/graph_building_env.py
@@ -1,5 +1,6 @@
 import copy
 import enum
+import json
 import re
 from collections import defaultdict
 from functools import cached_property
@@ -882,4 +883,6 @@ class GraphBuildingEnvContext:
 
     def object_to_log_repr(self, g: Graph) -> str:
         """Convert a Graph to a string representation for logging purposes"""
-        return ""
+        return json.dumps(
+            [[(i, g.nodes[i]) for i in g.nodes], [(e, g.edges[e]) for e in g.edges]], separators=(",", ":")
+        )

--- a/src/gflownet/envs/graph_building_env.py
+++ b/src/gflownet/envs/graph_building_env.py
@@ -879,3 +879,7 @@ class GraphBuildingEnvContext:
             The corresponding Graph representation of that molecule.
         """
         raise NotImplementedError()
+
+    def object_to_log_repr(self, g: Graph) -> str:
+        """Convert a Graph to a string representation for logging purposes"""
+        return ""

--- a/src/gflownet/envs/mol_building_env.py
+++ b/src/gflownet/envs/mol_building_env.py
@@ -457,3 +457,7 @@ class MolBuildingEnvContext(GraphBuildingEnvContext):
         if mol is None:
             return False
         return True
+
+    def object_to_log_repr(self, g: Graph):
+        """Convert a Graph to a string representation"""
+        return Chem.MolToSmiles(self.graph_to_mol(g))

--- a/src/gflownet/envs/mol_building_env.py
+++ b/src/gflownet/envs/mol_building_env.py
@@ -460,4 +460,9 @@ class MolBuildingEnvContext(GraphBuildingEnvContext):
 
     def object_to_log_repr(self, g: Graph):
         """Convert a Graph to a string representation"""
-        return Chem.MolToSmiles(self.graph_to_mol(g))
+        try:
+            mol = self.graph_to_mol(g)
+            assert mol is not None
+            return Chem.MolToSmiles(mol)
+        except Exception:
+            return ""

--- a/src/gflownet/envs/seq_building_env.py
+++ b/src/gflownet/envs/seq_building_env.py
@@ -1,13 +1,17 @@
-from typing import Any, List, Tuple
 from copy import deepcopy
+from typing import Any, List, Tuple
 
 import torch
-import torch_geometric.data as gd
-from torch_geometric.data import Data
 from torch.nn.utils.rnn import pad_sequence
+from torch_geometric.data import Data
 
-from gflownet.envs.graph_building_env import Graph, GraphAction
-from .graph_building_env import Graph, GraphAction, GraphActionType, GraphBuildingEnv, GraphBuildingEnvContext
+from gflownet.envs.graph_building_env import (
+    Graph,
+    GraphAction,
+    GraphActionType,
+    GraphBuildingEnv,
+    GraphBuildingEnvContext,
+)
 
 
 # For typing's sake, we'll pretend that a sequence is a graph.

--- a/src/gflownet/envs/seq_building_env.py
+++ b/src/gflownet/envs/seq_building_env.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, List, Sequence, Tuple
+from typing import Any, List, Tuple, Sequence
 
 import torch
 from torch.nn.utils.rnn import pad_sequence
@@ -20,7 +20,7 @@ class Seq(Graph):
         self.seq: list[Any] = []
 
     def __repr__(self):
-        return "".join(self.seq)
+        return "".join(map(str, self.seq))
 
     @property
     def nodes(self):
@@ -65,7 +65,7 @@ class SeqBatch:
         self.lens = torch.tensor([len(i) for i in seqs], dtype=torch.long)
         # This tells where (in the flattened array of outputs) the non-masked outputs are.
         # E.g. if the batch is [["ABC", "VWXYZ"]], logit_idx would be [0, 1, 2, 5, 6, 7, 8, 9]
-        self.logit_idx = self.x.ne(pad).flatten().nonzero().flatten()
+        self.logit_idx = self.x.ne(pad).T.flatten().nonzero().flatten()
         # Since we're feeding this batch object to graph-based algorithms, we have to use this naming, but this
         # is the total number of timesteps.
         self.num_graphs = self.lens.sum().item()
@@ -91,7 +91,7 @@ class AutoregressiveSeqBuildingContext(GraphBuildingEnvContext):
         self.num_tokens = len(alphabet) + 2  # Alphabet + BOS + PAD
         self.bos_token = len(alphabet)
         self.pad_token = len(alphabet) + 1
-        self.num_outputs = len(alphabet) + 1  # Alphabet + Stop
+        self.num_actions = len(alphabet) + 1  # Alphabet + Stop
         self.num_cond_dim = num_cond_dim
 
     def aidx_to_GraphAction(self, g: Data, action_idx: Tuple[int, int, int], fwd: bool = True) -> GraphAction:

--- a/src/gflownet/envs/seq_building_env.py
+++ b/src/gflownet/envs/seq_building_env.py
@@ -1,0 +1,120 @@
+from typing import Any, List, Tuple
+from copy import deepcopy
+
+import torch
+import torch_geometric.data as gd
+from torch_geometric.data import Data
+from torch.nn.utils.rnn import pad_sequence
+
+from gflownet.envs.graph_building_env import Graph, GraphAction
+from .graph_building_env import Graph, GraphAction, GraphActionType, GraphBuildingEnv, GraphBuildingEnvContext
+
+
+# For typing's sake, we'll pretend that a sequence is a graph.
+class Seq(Graph):
+    def __init__(self):
+        self.seq: list[Any] = []
+
+    def __repr__(self):
+        return "".join(self.seq)
+
+    @property
+    def nodes(self):
+        return self.seq
+
+
+class SeqBuildingEnv(GraphBuildingEnv):
+    """This class masquerades as a GraphBuildingEnv, but actually generates sequences of tokens."""
+
+    def __init__(self, variant):
+        super().__init__()
+
+    def new(self):
+        return Seq()
+
+    def step(self, g: Graph, a: GraphAction):
+        s: Seq = deepcopy(g)  # type: ignore
+        if a.action == GraphActionType.AddNode:
+            s.seq.append(a.value)
+        return s
+
+    def count_backward_transitions(self, g: Graph, check_idempotent: bool = False):
+        return 1
+
+    def parents(self, g: Graph):
+        s: Seq = deepcopy(g)  # type: ignore
+        if not len(s.seq):
+            return []
+        v = s.seq.pop()
+        return [(GraphAction(GraphActionType.AddNode, value=v), s)]
+
+    def reverse(self, g: Graph, ga: GraphAction):
+        # TODO: if we implement non-LR variants we'll need to do something here
+        return GraphAction(GraphActionType.Stop)
+
+
+class SeqBatch:
+    def __init__(self, seqs: List[torch.Tensor], pad: int):
+        self.seqs = seqs
+        self.x = pad_sequence(seqs, batch_first=False, padding_value=pad)
+        self.mask = self.x.eq(pad).T
+        self.lens = torch.tensor([len(i) for i in seqs], dtype=torch.long)
+        self.logit_idx = self.x.ne(pad).flatten().nonzero().flatten()
+        self.num_graphs = self.lens.sum().item()
+        # self.batch = torch.tensor([[i] * len(s) for i, s in enumerate(seqs)])
+
+    def to(self, device):
+        for name in dir(self):
+            x = getattr(self, name)
+            if isinstance(x, torch.Tensor):
+                setattr(self, name, x.to(device))
+        return self
+
+
+class GenericSeqBuildingContext(GraphBuildingEnvContext):
+    def __init__(self, alphabet, num_cond_dim=0):
+        self.alphabet = alphabet
+        self.action_type_order = [GraphActionType.Stop, GraphActionType.AddNode]
+
+        self.num_tokens = len(alphabet) + 2  # Alphabet + BOS + PAD
+        self.bos_token = len(alphabet)
+        self.pad_token = len(alphabet) + 1
+        self.num_outputs = len(alphabet) + 1  # Alphabet + Stop
+        self.num_cond_dim = num_cond_dim
+
+    def aidx_to_GraphAction(self, g: Data, action_idx: Tuple[int, int, int], fwd: bool = True) -> GraphAction:
+        act_type, _, act_col = [int(i) for i in action_idx]
+        t = self.action_type_order[act_type]
+        if t is GraphActionType.Stop:
+            return GraphAction(t)
+        elif t is GraphActionType.AddNode:
+            return GraphAction(t, value=act_col)
+        raise ValueError(action_idx)
+
+    def GraphAction_to_aidx(self, g: Data, action: GraphAction) -> Tuple[int, int, int]:
+        if action.action is GraphActionType.Stop:
+            col = 0
+            type_idx = self.action_type_order.index(action.action)
+        elif action.action is GraphActionType.AddNode:
+            col = action.value
+            type_idx = self.action_type_order.index(action.action)
+        else:
+            raise ValueError(action)
+        return (type_idx, 0, int(col))
+
+    def graph_to_Data(self, g: Graph):
+        s: Seq = g  # type: ignore
+        return torch.tensor([self.bos_token] + s.seq, dtype=torch.long)
+
+    def collate(self, graphs: List[Data]):
+        return SeqBatch(graphs, pad=self.pad_token)
+
+    def is_sane(self, g: Graph) -> bool:
+        return True
+
+    def graph_to_mol(self, g: Graph):
+        s: Seq = g  # type: ignore
+        return "".join(self.alphabet[i] for i in s.seq)
+
+    def object_to_log_repr(self, g: Graph):
+        return self.graph_to_mol(g)

--- a/src/gflownet/envs/seq_building_env.py
+++ b/src/gflownet/envs/seq_building_env.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, List, Tuple, Sequence
+from typing import Any, List, Sequence, Tuple
 
 import torch
 from torch.nn.utils.rnn import pad_sequence

--- a/src/gflownet/models/config.py
+++ b/src/gflownet/models/config.py
@@ -22,4 +22,5 @@ class ModelConfig:
 
     num_layers: int = 3
     num_emb: int = 128
+    dropout: float = 0
     graph_transformer: GraphTransformerConfig = GraphTransformerConfig()

--- a/src/gflownet/models/config.py
+++ b/src/gflownet/models/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum
 
 
 @dataclass
@@ -6,6 +7,17 @@ class GraphTransformerConfig:
     num_heads: int = 2
     ln_type: str = "pre"
     num_mlp_layers: int = 0
+
+
+class SeqPosEnc(Enum):
+    Pos = 0
+    Rotary = 1
+
+
+@dataclass
+class SeqTransformerConfig:
+    num_heads: int = 2
+    posenc: SeqPosEnc = SeqPosEnc.Rotary
 
 
 @dataclass
@@ -24,3 +36,4 @@ class ModelConfig:
     num_emb: int = 128
     dropout: float = 0
     graph_transformer: GraphTransformerConfig = GraphTransformerConfig()
+    seq_transformer: SeqTransformerConfig = SeqTransformerConfig()

--- a/src/gflownet/models/seq_transformer.py
+++ b/src/gflownet/models/seq_transformer.py
@@ -1,12 +1,11 @@
+import math
+
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
-import math
-import numpy as np
 
+from gflownet.config import Config
 from gflownet.envs.graph_building_env import GraphActionCategorical, GraphBuildingEnvContext
 from gflownet.envs.seq_building_env import SeqBatch
-from gflownet.config import Config
 
 
 class MLP(nn.Module):

--- a/src/gflownet/models/seq_transformer.py
+++ b/src/gflownet/models/seq_transformer.py
@@ -1,0 +1,120 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import math
+import numpy as np
+
+from gflownet.envs.graph_building_env import GraphActionCategorical, GraphBuildingEnvContext
+from gflownet.envs.seq_building_env import SeqBatch
+from gflownet.config import Config
+
+
+class MLP(nn.Module):
+    def __init__(self, in_dim, out_dim, hidden_layers, dropout_prob, init_drop=False):
+        super(MLP, self).__init__()
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+        layers = [nn.Linear(in_dim, hidden_layers[0]), nn.ReLU()]
+        layers += [nn.Dropout(dropout_prob)] if init_drop else []
+        for i in range(1, len(hidden_layers)):
+            layers.extend([nn.Linear(hidden_layers[i - 1], hidden_layers[i]), nn.ReLU(), nn.Dropout(dropout_prob)])
+        layers.append(nn.Linear(hidden_layers[-1], out_dim))
+        self.model = nn.Sequential(*layers)
+
+    def forward(self, x, with_uncertainty=False):
+        return self.model(x)
+
+
+class SeqTransformerGFN(nn.Module):
+    ctx: GraphBuildingEnvContext
+
+    def __init__(
+        self,
+        env_ctx,
+        cfg: Config,
+        num_state_out=1,
+    ):
+        super().__init__()
+        # num_hid, cond_dim, max_len, vocab_size, num_actions, dropout, num_layers, num_head, use_cond, **kwargs
+        self.ctx = env_ctx
+        num_hid = cfg.model.num_emb
+        num_outs = env_ctx.num_outputs + num_state_out
+        mc = cfg.model
+        self.pos = PositionalEncoding(num_hid, dropout=cfg.model.dropout, max_len=cfg.algo.max_len + 2)
+        self.use_cond = env_ctx.num_cond_dim > 0
+        self.embedding = nn.Embedding(env_ctx.num_tokens, num_hid)
+        encoder_layers = nn.TransformerEncoderLayer(
+            num_hid, mc.graph_transformer.num_heads, num_hid, dropout=mc.dropout
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layers, mc.num_layers)
+        self.logZ = nn.Linear(env_ctx.num_cond_dim, 1)
+        if self.use_cond:
+            self.output = MLP(num_hid + num_hid, num_outs, [4 * num_hid, 4 * num_hid], mc.dropout)
+            self.cond_embed = nn.Linear(env_ctx.num_cond_dim, num_hid)
+        else:
+            self.output = MLP(num_hid, num_outs, [2 * num_hid, 2 * num_hid], mc.dropout)
+        self.num_hid = num_hid
+
+    def forward(self, xs: SeqBatch, cond, batched=False):
+        x = self.embedding(xs.x)
+        x = self.pos(x)  # (time, batch, nemb)
+        x = self.encoder(x, src_key_padding_mask=xs.mask, mask=generate_square_subsequent_mask(x.shape[0]).to(x.device))
+        pooled_x = x[xs.lens - 1, torch.arange(x.shape[1])]  # (batch, nemb)
+
+        if self.use_cond:
+            cond_var = self.cond_embed(cond)  # (batch, nemb)
+            cond_var = torch.tile(cond_var, (x.shape[0], 1, 1)) if batched else cond_var
+            final_rep = torch.cat((x, cond_var), axis=-1) if batched else torch.cat((pooled_x, cond_var), axis=-1)
+        else:
+            final_rep = x if batched else pooled_x
+
+        out: torch.Tensor = self.output(final_rep)
+        if batched:
+            # out is (time, batch, nout)
+            out = out.transpose(1, 0).contiguous().reshape((-1, out.shape[2]))  # (batch * time, nout)
+            stop_logits = out[xs.logit_idx, 0:1]  # (proper_time, 1)
+            state_preds = out[xs.logit_idx, 1:2]  # (proper_time, 1)
+            add_node_logits = out[xs.logit_idx, 2:]  # (proper_time, nout - 1)
+            # `time` above is really max_time, whereas proper_time = sum(len(traj) for traj in xs))
+            # which is what we need to give to GraphActionCategorical
+        else:
+            # The default num_graphs is computed for the batched case, so we need to fix it here so that
+            # GraphActionCategorical knows how many "graphs" (sequence inputs) there are
+            xs.num_graphs = out.shape[0]
+            # out is (batch, nout)
+            stop_logits = out[:, 0:1]
+            state_preds = out[:, 1:2]
+            add_node_logits = out[:, 2:]
+
+        return (
+            GraphActionCategorical(
+                xs,
+                logits=[stop_logits, add_node_logits],
+                keys=[None, None],
+                types=self.ctx.action_type_order,
+                slice_dict={},
+            ),
+            state_preds,
+        )
+
+
+def generate_square_subsequent_mask(sz: int):
+    """Generates an upper-triangular matrix of -inf, with zeros on diag."""
+    return torch.triu(torch.ones(sz, sz) * float("-inf"), diagonal=1)
+
+
+class PositionalEncoding(nn.Module):
+    def __init__(self, d_model, dropout=0.1, max_len=5000):
+        super(PositionalEncoding, self).__init__()
+        self.dropout = nn.Dropout(p=dropout)
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model))
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0).transpose(0, 1)
+        self.register_buffer("pe", pe)
+
+    def forward(self, x):
+        x = x + self.pe[: x.size(0), :]
+        return self.dropout(x)

--- a/src/gflownet/tasks/toy_seq.py
+++ b/src/gflownet/tasks/toy_seq.py
@@ -1,0 +1,133 @@
+import os
+import shutil
+import socket
+from typing import Callable, Dict, List, Tuple, Union
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch_geometric.data as gd
+from rdkit.Chem.rdchem import Mol as RDMol
+from torch import Tensor
+from torch.utils.data import Dataset
+
+from gflownet.config import Config
+from gflownet.envs.seq_building_env import GenericSeqBuildingContext, SeqBuildingEnv
+from gflownet.models.seq_transformer import SeqTransformerGFN
+from gflownet.online_trainer import StandardOnlineTrainer
+from gflownet.trainer import FlatRewards, GFNTask, RewardScalar
+from gflownet.utils.conditioning import TemperatureConditional
+
+
+class ToySeqTask(GFNTask):
+    """Sets up a task where the reward is the number of times some sequences appear in the input"""
+
+    def __init__(
+        self,
+        seqs: List[str],
+        cfg: Config,
+        rng: np.random.Generator,
+    ):
+        self.seqs = seqs
+        self.temperature_conditional = TemperatureConditional(cfg, rng)
+        self.num_cond_dim = self.temperature_conditional.encoding_size()
+        self.norm = cfg.algo.max_len / min(map(len, seqs))
+
+    def sample_conditional_information(self, n: int, train_it: int) -> Dict[str, Tensor]:
+        return self.temperature_conditional.sample(n)
+
+    def cond_info_to_logreward(self, cond_info: Dict[str, Tensor], flat_reward: FlatRewards) -> RewardScalar:
+        return RewardScalar(self.temperature_conditional.transform(cond_info, flat_reward))
+
+    def compute_flat_rewards(self, objs: List[str]) -> Tuple[FlatRewards, Tensor]:
+        rs = torch.tensor([sum([s.count(p) for p in self.seqs]) for s in objs]).float() / self.norm
+        return FlatRewards(rs[:, None]), torch.ones(len(objs), dtype=torch.bool)
+
+
+class ToySeqTrainer(StandardOnlineTrainer):
+    task: ToySeqTask
+
+    def set_default_hps(self, cfg: Config):
+        cfg.hostname = socket.gethostname()
+        cfg.pickle_mp_messages = False
+        cfg.num_workers = 8
+        cfg.opt.learning_rate = 1e-4
+        cfg.opt.weight_decay = 1e-8
+        cfg.opt.momentum = 0.9
+        cfg.opt.adam_eps = 1e-8
+        cfg.opt.lr_decay = 20_000
+        cfg.opt.clip_grad_type = "norm"
+        cfg.opt.clip_grad_param = 10
+        cfg.algo.global_batch_size = 64
+        cfg.algo.offline_ratio = 0
+        cfg.model.num_emb = 64
+        cfg.model.num_layers = 4
+
+        cfg.algo.method = "TB"
+        cfg.algo.max_nodes = 10
+        cfg.algo.max_len = 10
+        cfg.algo.sampling_tau = 0.9
+        cfg.algo.illegal_action_logreward = -75
+        cfg.algo.train_random_action_prob = 0.0
+        cfg.algo.valid_random_action_prob = 0.0
+        cfg.algo.valid_offline_ratio = 0
+        cfg.algo.tb.epsilon = None
+        cfg.algo.tb.bootstrap_own_reward = False
+        cfg.algo.tb.Z_learning_rate = 1e-3
+        cfg.algo.tb.Z_lr_decay = 50_000
+        cfg.algo.tb.do_parameterize_p_b = False
+
+    def setup_model(self):
+        self.model = SeqTransformerGFN(
+            self.ctx,
+            self.cfg,
+        )
+
+    def setup_task(self):
+        self.task = ToySeqTask(
+            ["aa", "bb", "cc"],
+            cfg=self.cfg,
+            rng=self.rng,
+        )
+
+    def setup_env_context(self):
+        self.env = SeqBuildingEnv(None)
+        self.ctx = GenericSeqBuildingContext(
+            "abc",
+            self.task.num_cond_dim,
+        )
+
+    def setup_algo(self):
+        super().setup_algo()
+        self.algo.model_is_autoregressive = True
+
+
+def main():
+    """Example of how this model can be run outside of Determined"""
+    hps = {
+        "log_dir": "./logs/debug_run_toy_seq",
+        "device": "cuda",
+        "overwrite_existing_exp": True,
+        "num_training_steps": 10_000,
+        "num_workers": 4,
+        "cond": {
+            "temperature": {
+                "sample_dist": "uniform",
+                "dist_params": [2.0, 2.01],
+            }
+        },
+    }
+    if os.path.exists(hps["log_dir"]):
+        if hps["overwrite_existing_exp"]:
+            shutil.rmtree(hps["log_dir"])
+        else:
+            raise ValueError(f"Log dir {hps['log_dir']} already exists. Set overwrite_existing_exp=True to delete it.")
+    os.makedirs(hps["log_dir"])
+
+    trial = ToySeqTrainer(hps)
+    trial.print_every = 1
+    trial.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gflownet/tasks/toy_seq.py
+++ b/src/gflownet/tasks/toy_seq.py
@@ -1,15 +1,11 @@
 import os
 import shutil
 import socket
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Dict, List, Tuple
 
 import numpy as np
 import torch
-import torch.nn as nn
-import torch_geometric.data as gd
-from rdkit.Chem.rdchem import Mol as RDMol
 from torch import Tensor
-from torch.utils.data import Dataset
 
 from gflownet.config import Config
 from gflownet.envs.seq_building_env import GenericSeqBuildingContext, SeqBuildingEnv

--- a/src/gflownet/tasks/toy_seq.py
+++ b/src/gflownet/tasks/toy_seq.py
@@ -70,7 +70,7 @@ class ToySeqTrainer(StandardOnlineTrainer):
         cfg.algo.valid_offline_ratio = 0
         cfg.algo.tb.epsilon = None
         cfg.algo.tb.bootstrap_own_reward = False
-        cfg.algo.tb.Z_learning_rate = 1e-3
+        cfg.algo.tb.Z_learning_rate = 1e-2
         cfg.algo.tb.Z_lr_decay = 50_000
         cfg.algo.tb.do_parameterize_p_b = False
 
@@ -108,14 +108,17 @@ def main():
         "log_dir": "./logs/debug_run_toy_seq",
         "device": "cuda",
         "overwrite_existing_exp": True,
-        "num_training_steps": 10_000,
+        "num_training_steps": 2_000,
+        "checkpoint_every": 200,
         "num_workers": 4,
         "cond": {
             "temperature": {
-                "sample_dist": "uniform",
-                "dist_params": [2.0, 2.01],
+                "sample_dist": "constant",
+                "dist_params": [2.0],
+                "num_thermometer_dim": 1,
             }
         },
+        "algo": {"train_random_action_prob": 0.05},
     }
     if os.path.exists(hps["log_dir"]):
         if hps["overwrite_existing_exp"]:

--- a/src/gflownet/trainer.py
+++ b/src/gflownet/trainer.py
@@ -16,6 +16,7 @@ from torch.utils.data import DataLoader, Dataset
 from gflownet.data.replay_buffer import ReplayBuffer
 from gflownet.data.sampling_iterator import SamplingIterator
 from gflownet.envs.graph_building_env import GraphActionCategorical, GraphBuildingEnv, GraphBuildingEnvContext
+from gflownet.envs.seq_building_env import SeqBatch
 from gflownet.utils.misc import create_logger
 from gflownet.utils.multiprocessing_proxy import mp_object_wrapper
 
@@ -175,7 +176,7 @@ class GFNTrainer:
             placeholder = mp_object_wrapper(
                 obj,
                 self.cfg.num_workers,
-                cast_types=(gd.Batch, GraphActionCategorical),
+                cast_types=(gd.Batch, GraphActionCategorical, SeqBatch),
                 pickle_messages=self.cfg.pickle_mp_messages,
             )
             return placeholder, torch.device("cpu")


### PR DESCRIPTION
This PR adds support for left-to-right sequence generation with GFNs.

PR changes:
- Adds a `model_is_autoregressive` option in trajectory balance, which avoids unnecessary computations in the AR case
- Simplifies `SamplingIterator` somewhat by letting contexts defined how they want their objects logged
- Adds an optional `slice_dict` parameter to `GraphActionCategorical` (useful to reuse this class for sequences)
- Adds `SeqBuildingEnv` and `AutoregressiveSeqBuildingContext`, which implement LR sequence generation MDPs
- Adds a standard `SeqTransformerGFN` as a sequence model
- Adds a `ToySeqTask` to show how to use the introduced features (the task itself is to produce sequences with doubled letters in them).