### PR TITLE
Separate P_B trunk & min_len 

### DIFF
--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -34,3 +34,15 @@ The code contains a specific categorical distribution type for graph actions, `G
 Consider for example the `AddNode` and `SetEdgeAttr` actions, one applies to nodes and one to edges. An efficient way to produce logits for these actions would be to take the node/edge embeddings and project them (e.g. via an MLP) to a `(n_nodes, n_node_actions)` and `(n_edges, n_edge_actions)` tensor respectively. We thus obtain a list of tensors representing the logits of different actions, but logits are mixed between graphs in the minibatch, so one cannot simply apply a `softmax` operator on the tensor. 
 
 The `GraphActionCategorical` class handles this and can be used to compute various other things, such as entropy, log probabilities, and so on; it can also be used to sample from the distribution.
+
+### Min/max trajectory length
+
+The current way min/max trajectory lengths are handled is somewhat contrived (contributions welcome!) for historical reasons.
+
+- min length: a `GraphBuildingEnvContext`'s `graph_to_Data(g, t)` receives the timestep as its second argument. The responsibility of masking the stop action is left to the context to enforce _minimum_ trajectory lengths.
+- max length: the `GraphSampler` class enforces maximum length and maximum number of nodes by terminating the trajectory if either condition is met.
+- max size: both `MolBuildingEnvContext` and `FragMolBuildingEnvContext` implement a `max_nodes`/`max_frags` property that is used to mask the `AddNode` action. 
+
+Sequence environments differ somewhat, it's left to the `SeqTransformer` class to mask the stop action using the `min_len` parameter.
+
+To output fixed-length trajectories it should be sufficient to set `cfg.algo.min_len` and `cfg.algo.max_len` to the same value. Note that in some cases, e.g. when building fragment graphs, the agent may still output trajectories that are shorter than `min_len` by combining two fragments of degree one (leaving no valid action but to stop).

--- a/src/gflownet/algo/advantage_actor_critic.py
+++ b/src/gflownet/algo/advantage_actor_critic.py
@@ -115,7 +115,7 @@ class A2C:
         batch: gd.Batch
              A (CPU) Batch object with relevant attributes added
         """
-        torch_graphs = [self.ctx.graph_to_Data(i[0]) for tj in trajs for i in tj["traj"]]
+        torch_graphs = [self.ctx.graph_to_Data(i[0], t) for tj in trajs for t, i in enumerate(tj["traj"])]
         actions = [
             self.ctx.GraphAction_to_aidx(g, a) for g, a in zip(torch_graphs, [i[1] for tj in trajs for i in tj["traj"]])
         ]

--- a/src/gflownet/algo/config.py
+++ b/src/gflownet/algo/config.py
@@ -97,6 +97,9 @@ class AlgoConfig:
         The name of the algorithm to use (e.g. "TB")
     global_batch_size : int
         The batch size for training
+    min_len: int
+        If >0, prevents the agent from using the Stop action before min_len steps (trajectories may still end for
+        other reasons, but generally setting min_len==max_len should produce fixed length trajectories).
     max_len : int
         The maximum length of a trajectory
     max_nodes : int
@@ -124,6 +127,7 @@ class AlgoConfig:
 
     method: str = "TB"
     global_batch_size: int = 64
+    min_len: int = 0
     max_len: int = 128
     max_nodes: int = 128
     max_edges: int = 128

--- a/src/gflownet/algo/envelope_q_learning.py
+++ b/src/gflownet/algo/envelope_q_learning.py
@@ -269,7 +269,7 @@ class EnvelopeQLearning:
         batch: gd.Batch
              A (CPU) Batch object with relevant attributes added
         """
-        torch_graphs = [self.ctx.graph_to_Data(i[0]) for tj in trajs for i in tj["traj"]]
+        torch_graphs = [self.ctx.graph_to_Data(i[0], t) for tj in trajs for t, i in enumerate(tj["traj"])]
         actions = [
             self.ctx.GraphAction_to_aidx(g, a) for g, a in zip(torch_graphs, [i[1] for tj in trajs for i in tj["traj"]])
         ]

--- a/src/gflownet/algo/soft_q_learning.py
+++ b/src/gflownet/algo/soft_q_learning.py
@@ -111,7 +111,7 @@ class SoftQLearning:
         batch: gd.Batch
              A (CPU) Batch object with relevant attributes added
         """
-        torch_graphs = [self.ctx.graph_to_Data(i[0]) for tj in trajs for i in tj["traj"]]
+        torch_graphs = [self.ctx.graph_to_Data(i[0], t) for tj in trajs for t, i in enumerate(tj["traj"])]
         actions = [
             self.ctx.GraphAction_to_aidx(g, a) for g, a in zip(torch_graphs, [i[1] for tj in trajs for i in tj["traj"]])
         ]

--- a/src/gflownet/algo/trajectory_balance.py
+++ b/src/gflownet/algo/trajectory_balance.py
@@ -288,10 +288,12 @@ class TrajectoryBalance(GFNAlgorithm):
              A (CPU) Batch object with relevant attributes added
         """
         if self.model_is_autoregressive:
-            torch_graphs = [self.ctx.graph_to_Data(tj["traj"][-1][0]) for tj in trajs]
+            # Since we're passing the entire sequence to an autoregressive model, it becomes its responsibility to deal
+            # with `t` (which is always just len(s)).
+            torch_graphs = [self.ctx.graph_to_Data(tj["traj"][-1][0], t=0) for tj in trajs]
             actions = [self.ctx.GraphAction_to_aidx(g, i[1]) for g, tj in zip(torch_graphs, trajs) for i in tj["traj"]]
         else:
-            torch_graphs = [self.ctx.graph_to_Data(i[0]) for tj in trajs for i in tj["traj"]]
+            torch_graphs = [self.ctx.graph_to_Data(i[0], t) for tj in trajs for t, i in enumerate(tj["traj"])]
             actions = [
                 self.ctx.GraphAction_to_aidx(g, a)
                 for g, a in zip(torch_graphs, [i[1] for tj in trajs for i in tj["traj"]])

--- a/src/gflownet/envs/graph_building_env.py
+++ b/src/gflownet/envs/graph_building_env.py
@@ -892,12 +892,14 @@ class GraphBuildingEnvContext:
         """
         raise NotImplementedError()
 
-    def graph_to_Data(self, g: Graph) -> gd.Data:
+    def graph_to_Data(self, g: Graph, t: int) -> gd.Data:
         """Convert a networkx Graph to a torch geometric Data instance
         Parameters
         ----------
         g: Graph
             A graph instance.
+        t:
+            The current timestep (may be ignored by some contexts)
 
         Returns
         -------

--- a/src/gflownet/envs/seq_building_env.py
+++ b/src/gflownet/envs/seq_building_env.py
@@ -22,6 +22,9 @@ class Seq(Graph):
     def __repr__(self):
         return "".join(map(str, self.seq))
 
+    def __len__(self) -> int:
+        return len(self.seq)
+
     @property
     def nodes(self):
         return self.seq
@@ -84,7 +87,7 @@ class AutoregressiveSeqBuildingContext(GraphBuildingEnvContext):
     This context gets an agent to generate sequences of tokens from left to right, i.e. in an autoregressive fashion.
     """
 
-    def __init__(self, alphabet: Sequence[str], num_cond_dim=0):
+    def __init__(self, alphabet: Sequence[str], num_cond_dim=0, min_len=0):
         self.alphabet = alphabet
         self.action_type_order = [GraphActionType.Stop, GraphActionType.AddNode]
 
@@ -93,6 +96,7 @@ class AutoregressiveSeqBuildingContext(GraphBuildingEnvContext):
         self.pad_token = len(alphabet) + 1
         self.num_actions = len(alphabet) + 1  # Alphabet + Stop
         self.num_cond_dim = num_cond_dim
+        self.min_len = min_len
 
     def aidx_to_GraphAction(self, g: Data, action_idx: Tuple[int, int, int], fwd: bool = True) -> GraphAction:
         # Since there's only one "object" per timestep to act upon (in graph parlance), the row is always == 0
@@ -115,7 +119,7 @@ class AutoregressiveSeqBuildingContext(GraphBuildingEnvContext):
             raise ValueError(action)
         return (type_idx, 0, int(col))
 
-    def graph_to_Data(self, g: Graph):
+    def graph_to_Data(self, g: Graph, t: int):
         s: Seq = g  # type: ignore
         return torch.tensor([self.bos_token] + s.seq, dtype=torch.long)
 

--- a/src/gflownet/models/config.py
+++ b/src/gflownet/models/config.py
@@ -30,10 +30,16 @@ class ModelConfig:
         The number of layers in the model
     num_emb : int
         The number of dimensions of the embedding
+    dropout : float
+        The dropout probability in intermediate layers
+    separate_pB : bool
+        If true, constructs the backward policy using a separate model (this effectively ~doubles the number of
+        parameters, all other things being equal)
     """
 
     num_layers: int = 3
     num_emb: int = 128
     dropout: float = 0
+    do_separate_p_b: bool = False
     graph_transformer: GraphTransformerConfig = GraphTransformerConfig()
     seq_transformer: SeqTransformerConfig = SeqTransformerConfig()

--- a/src/gflownet/models/seq_transformer.py
+++ b/src/gflownet/models/seq_transformer.py
@@ -36,9 +36,11 @@ class SeqTransformerGFN(nn.Module):
         env_ctx,
         cfg: Config,
         num_state_out=1,
+        min_len=0,
     ):
         super().__init__()
         self.ctx = env_ctx
+        self.min_len = min_len
         self.num_state_out = num_state_out
         num_hid = cfg.model.num_emb
         num_outs = env_ctx.num_actions + num_state_out
@@ -96,6 +98,12 @@ class SeqTransformerGFN(nn.Module):
             add_node_logits = out[xs.logit_idx, ns + 1 :]  # (proper_time, nout - 1)
             # `time` above is really max_time, whereas proper_time = sum(len(traj) for traj in xs))
             # which is what we need to give to GraphActionCategorical
+            stop_mask = torch.ones_like(stop_logits)
+            if self.min_len > 0:
+                # The +1 accounts for the BOS token
+                stop_mask = torch.cat([torch.arange(1, i + 1) >= self.min_len for i in xs.lens])
+                stop_mask = stop_mask.to(stop_logits.device).float().unsqueeze(-1)
+                stop_logits = stop_logits * stop_mask - 1000 * (1 - stop_mask)
         else:
             # The default num_graphs is computed for the batched case, so we need to fix it here so that
             # GraphActionCategorical knows how many "graphs" (sequence inputs) there are
@@ -104,6 +112,11 @@ class SeqTransformerGFN(nn.Module):
             state_preds = out[:, 0:ns]
             stop_logits = out[:, ns : ns + 1]
             add_node_logits = out[:, ns + 1 :]
+            stop_mask = torch.ones_like(stop_logits)
+            if self.min_len > 0:
+                # The +1 accounts for the BOS token
+                stop_mask = stop_mask * (xs.lens >= self.min_len + 1).unsqueeze(-1).float()
+                stop_logits = stop_logits * stop_mask - 1000 * (1 - stop_mask)
 
         return (
             GraphActionCategorical(
@@ -111,6 +124,7 @@ class SeqTransformerGFN(nn.Module):
                 logits=[stop_logits, add_node_logits],
                 keys=[None, None],
                 types=self.ctx.action_type_order,
+                masks=[stop_mask, torch.ones_like(add_node_logits)],
                 slice_dict={},
             ),
             state_preds,

--- a/src/gflownet/models/seq_transformer.py
+++ b/src/gflownet/models/seq_transformer.py
@@ -60,6 +60,8 @@ class SeqTransformerGFN(nn.Module):
         else:
             self.output = MLPWithDropout(num_hid, num_outs, [2 * num_hid, 2 * num_hid], mc.dropout)
         self.num_hid = num_hid
+        # TODO: Merge non-autoregressive implementations of sequence generation
+        assert not cfg.model.do_separate_pb, "Not implemented for SeqTransformerGFN (since P_B=1 when autoregressive)."
 
     def forward(self, xs: SeqBatch, cond, batched=False):
         """Returns a GraphActionCategorical and a tensor of state predictions.

--- a/src/gflownet/tasks/seh_frag.py
+++ b/src/gflownet/tasks/seh_frag.py
@@ -192,6 +192,7 @@ class SEHFragTrainer(StandardOnlineTrainer):
             max_frags=self.cfg.algo.max_nodes,
             num_cond_dim=self.task.num_cond_dim,
             fragments=bengio2021flow.FRAGMENTS_18 if self.cfg.task.seh.reduced_frag else bengio2021flow.FRAGMENTS,
+            min_len=self.cfg.algo.min_len,
         )
 
     def setup(self):

--- a/src/gflownet/tasks/toy_seq.py
+++ b/src/gflownet/tasks/toy_seq.py
@@ -63,6 +63,7 @@ class ToySeqTrainer(StandardOnlineTrainer):
 
         cfg.algo.method = "TB"
         cfg.algo.max_nodes = 10
+        cfg.algo.min_len = 10
         cfg.algo.max_len = 10
         cfg.algo.sampling_tau = 0.9
         cfg.algo.illegal_action_logreward = -75
@@ -79,6 +80,7 @@ class ToySeqTrainer(StandardOnlineTrainer):
         self.model = SeqTransformerGFN(
             self.ctx,
             self.cfg,
+            min_len=self.cfg.algo.min_len,
         )
 
     def setup_task(self):
@@ -93,6 +95,7 @@ class ToySeqTrainer(StandardOnlineTrainer):
         self.ctx = AutoregressiveSeqBuildingContext(
             "abc",
             self.task.num_cond_dim,
+            self.cfg.algo.min_len,
         )
 
     def setup_algo(self):

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -49,7 +49,7 @@ def build_two_node_states(ctx):
 
     def expand(s, idx):
         # Recursively expand all children of s
-        gd = ctx.graph_to_Data(s)
+        gd = ctx.graph_to_Data(s, t=0)
         masks = [getattr(gd, gat.mask_name) for gat in ctx.action_type_order]
         for at, mask in enumerate(masks):
             if at == 0:  # Ignore Stop action
@@ -116,7 +116,7 @@ def _test_backwards_mask_equivalence(two_node_states, ctx):
         g = two_node_states[i]
         n = env.count_backward_transitions(g, check_idempotent=False)
         nm = 0
-        gd = ctx.graph_to_Data(g)
+        gd = ctx.graph_to_Data(g, t=0)
         for u, k in enumerate(ctx.bck_action_type_order):
             m = getattr(gd, k.mask_name)
             nm += m.sum()
@@ -138,7 +138,7 @@ def _test_backwards_mask_equivalence_ipa(two_node_states, ctx):
     for i in range(1, len(two_node_states)):
         g = two_node_states[i]
         n = env.count_backward_transitions(g, check_idempotent=True)
-        gd = ctx.graph_to_Data(g)
+        gd = ctx.graph_to_Data(g, t=0)
         # To check that we're computing masks correctly, we need to check that there is the same
         # number of idempotent action classes, i.e. groups of actions that lead to the same parent.
         equivalence_classes = []


### PR DESCRIPTION
This PR makes it possible to have a separate set of parameters for P_B by setting `cfg.model.do_separate_p_b`. It also introduces `cfg.algo.min_len`, which defaults to `0` and prevents and agent from stopping before `min_len` steps have been taken.

Other changes:
- This change required adding a timestep parameter to `graph_to_Data` across contexts.
- While debugging I added a `consider_masks_complete` flag to contexts, which indicates when masks computed by a context should be taken as ground truth in terms of which actions are valid. This should help in some aspects in the future (e.g. counting parents, debugging new masks).
- Adds explicit mask computation in `SeqTransformerGFN`