### PR TITLE
Add backward sampling

### DIFF
--- a/docs/examples/grid_cond_gfn.py
+++ b/docs/examples/grid_cond_gfn.py
@@ -253,7 +253,7 @@ class FlowNet_TBAgent:
         return log_ratio
 
     def learn_from(self, it, batch):
-        if type(batch) is list:
+        if isinstance(batch, list):
             log_ratio = torch.stack(batch, 0)
         else:
             log_ratio = batch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,10 @@ requires-python = ">=3.8,<3.10"
 dynamic = ["version"]
 dependencies = [
     "torch==1.13.1",
-    "torch-geometric",
-    "torch-scatter",
-    "torch-sparse",
-    "torch-cluster",
+    "torch-geometric==2.3.1",  # Pinning until we adapt the code to newer versions
+    "torch-scatter==2.1.1",
+    "torch-sparse==0.6.17",
+    "torch-cluster==1.6.1",
     "rdkit",
     "tables",
     "scipy",

--- a/src/gflownet/algo/config.py
+++ b/src/gflownet/algo/config.py
@@ -45,6 +45,7 @@ class TBConfig:
     variant: TBVariant = TBVariant.TB
     do_correct_idempotent: bool = False
     do_parameterize_p_b: bool = False
+    do_sample_p_b: bool = False
     do_length_normalize: bool = False
     subtb_max_len: int = 128
     Z_learning_rate: float = 1e-4

--- a/src/gflownet/algo/graph_sampling.py
+++ b/src/gflownet/algo/graph_sampling.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from gflownet.envs.graph_building_env import Graph, GraphAction, GraphActionType, GraphActionCategorical
+from gflownet.envs.graph_building_env import Graph, GraphAction, GraphActionCategorical, GraphActionType
 from gflownet.models.graph_transformer import GraphTransformerGFN
 
 

--- a/src/gflownet/algo/graph_sampling.py
+++ b/src/gflownet/algo/graph_sampling.py
@@ -5,7 +5,25 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from gflownet.envs.graph_building_env import GraphAction, GraphActionType
+from gflownet.envs.graph_building_env import Graph, GraphAction, GraphActionType, GraphActionCategorical
+from gflownet.models.graph_transformer import GraphTransformerGFN
+
+
+def relabel(g: Graph, ga: GraphAction):
+    """Relabel the nodes for g to 0-N, and the graph action ga applied to g.
+    This is necessary because torch_geometric and EnvironmentContext classes expect nodes to be
+    labeled 0-N, whereas GraphBuildingEnv.parent can return parents with e.g. a removed node that
+    creates a gap in 0-N, leading to a faulty encoding of the graph.
+    """
+    rmap = dict(zip(g.nodes, range(len(g.nodes))))
+    if not len(g) and ga.action == GraphActionType.AddNode:
+        rmap[0] = 0  # AddNode can add to the empty graph, the source is still 0
+    g = g.relabel_nodes(rmap)
+    if ga.source is not None:
+        ga.source = rmap[ga.source]
+    if ga.target is not None:
+        ga.target = rmap[ga.target]
+    return g, ga
 
 
 class GraphSampler:
@@ -182,6 +200,100 @@ class GraphSampler:
             if self.pad_with_terminal_state:
                 # TODO: instead of padding with Stop, we could have a virtual action whose
                 # probability always evaluates to 1.
+                data[i]["traj"].append((graphs[i], GraphAction(GraphActionType.Stop)))
+                data[i]["is_sink"].append(1)
+        return data
+
+    def sample_backward_from_graphs(
+        self,
+        graphs: List[Graph],
+        model: nn.Module,
+        cond_info: Tensor,
+        dev: torch.device,
+        random_action_prob: float = 0.0,
+    ):
+        """Sample a model's P_B starting from a list of graphs, or if the model doesn't parameterize P_B, use a uniform
+        distribution over legal actions.
+
+        Parameters
+        ----------
+        graphs: List[Graph]
+            List of Graph endpoints
+        model: nn.Module
+            Model whose forward() method returns GraphActionCategorical instances
+        cond_info: Tensor
+            Conditional information of each trajectory, shape (n, n_info)
+        dev: torch.device
+            Device on which data is manipulated
+        random_action_prob: float
+            Probability of taking a random action (only used if model parameterizes P_B)
+
+        """
+        n = len(graphs)
+        done = [False] * n
+        data = [
+            {
+                "traj": [(graphs[i], GraphAction(GraphActionType.Stop))],
+                "is_valid": True,
+                "is_sink": [1],
+                "bck_a": [GraphAction(GraphActionType.Stop)],
+                "result": graphs[i],
+            }
+            for i in range(n)
+        ]
+
+        def not_done(lst):
+            return [e for i, e in enumerate(lst) if not done[i]]
+
+        if random_action_prob > 0:
+            raise NotImplementedError("Random action not implemented for backward sampling")
+
+        while sum(done) < n:
+            torch_graphs = [self.ctx.graph_to_Data(graphs[i]) for i in not_done(range(n))]
+            not_done_mask = torch.tensor(done, device=dev).logical_not()
+            fwd_cat, bck_cat, *_ = model(self.ctx.collate(torch_graphs).to(dev), cond_info[not_done_mask])
+            if not isinstance(bck_cat, GraphActionCategorical):
+                # A model with no parameterized P_B just returns (fwd_cat: GraphActionCategorical, graph_out: Tensor)
+                # At this point we interpret this as a model with a uniform P_B, and use the masks to sample
+                # uniformly over legal actions
+                gbatch = self.ctx.collate(torch_graphs)
+                action_types = self.ctx.bck_action_type_order
+                masks = [getattr(gbatch, i.mask_name) for i in action_types]
+                bck_cat = GraphActionCategorical(
+                    gbatch,
+                    logits=[m * 1e6 for m in masks],
+                    keys=[
+                        # TODO: This is not very clean, could probably abstract this away somehow
+                        GraphTransformerGFN._graph_part_to_key[GraphTransformerGFN._action_type_to_graph_part[t]]
+                        for t in action_types
+                    ],
+                    masks=masks,
+                    types=action_types,
+                )
+            bck_actions = bck_cat.sample()
+            graph_bck_actions = [
+                self.ctx.aidx_to_GraphAction(g, a, fwd=False) for g, a in zip(torch_graphs, bck_actions)
+            ]
+
+            for i, j in zip(not_done(range(n)), range(n)):
+                if not done[i]:
+                    g = graphs[i]
+                    b_a = graph_bck_actions[j]
+                    gp = self.env.step(g, b_a)
+                    f_a = self.env.reverse(g, b_a)
+                    graphs[i], f_a = relabel(gp, f_a)
+                    data[i]["traj"].append((g, f_a))
+                    data[i]["bck_a"].append(b_a)
+                    data[i]["is_sink"].append(0)
+                    if len(graphs[i]) == 0:
+                        done[i] = True
+
+        for i in range(n):
+            # See comments in sample_from_model
+            data[i]["traj"] = data[i]["traj"][::-1]
+            data[i]["bck_a"] = [GraphAction(GraphActionType.Stop)] + data[i]["bck_a"][::-1]
+            data[i]["is_sink"] = data[i]["is_sink"][::-1]
+            if self.pad_with_terminal_state:
                 data[i]["traj"].append((graphs[i], GraphAction(GraphActionType.Stop)))
                 data[i]["is_sink"].append(1)
         return data

--- a/src/gflownet/algo/trajectory_balance.py
+++ b/src/gflownet/algo/trajectory_balance.py
@@ -203,7 +203,9 @@ class TrajectoryBalance(GFNAlgorithm):
             assert model is not None and cond_info is not None and random_action_prob is not None
             dev = self.ctx.device
             cond_info = cond_info.to(dev)
-            return self.graph_sampler.sample_backward_from_graphs(graphs, model, cond_info, dev, random_action_prob)
+            return self.graph_sampler.sample_backward_from_graphs(
+                graphs, model if self.cfg.do_parameterize_p_b else None, cond_info, dev, random_action_prob
+            )
         trajs = [{"traj": generate_forward_trajectory(i)} for i in graphs]
         for traj in trajs:
             n_back = [

--- a/src/gflownet/algo/trajectory_balance.py
+++ b/src/gflownet/algo/trajectory_balance.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
 import networkx as nx
 import numpy as np
@@ -148,8 +148,8 @@ class TrajectoryBalance(GFNAlgorithm):
         ----------
         model: TrajectoryBalanceModel
            The model being sampled
-        graphs: List[Graph]
-            List of N Graph endpoints
+        n: int
+            Number of trajectories to sample
         cond_info: torch.tensor
             Conditional information, shape (N, n_info)
         random_action_prob: float
@@ -174,19 +174,36 @@ class TrajectoryBalance(GFNAlgorithm):
             data[i]["logZ"] = logZ_pred[i].item()
         return data
 
-    def create_training_data_from_graphs(self, graphs):
+    def create_training_data_from_graphs(
+        self,
+        graphs,
+        model: Optional[TrajectoryBalanceModel] = None,
+        cond_info: Optional[Tensor] = None,
+        random_action_prob: Optional[float] = None,
+    ):
         """Generate trajectories from known endpoints
 
         Parameters
         ----------
         graphs: List[Graph]
             List of Graph endpoints
+        model: TrajectoryBalanceModel
+           The model being sampled
+        cond_info: torch.tensor
+            Conditional information, shape (N, n_info)
+        random_action_prob: float
+            Probability of taking a random action
 
         Returns
         -------
         trajs: List[Dict{'traj': List[tuple[Graph, GraphAction]]}]
            A list of trajectories.
         """
+        if self.cfg.do_sample_p_b:
+            assert model is not None and cond_info is not None and random_action_prob is not None
+            dev = self.ctx.device
+            cond_info = cond_info.to(dev)
+            return self.graph_sampler.sample_backward_from_graphs(graphs, model, cond_info, dev, random_action_prob)
         trajs = [{"traj": generate_forward_trajectory(i)} for i in graphs]
         for traj in trajs:
             n_back = [

--- a/src/gflownet/data/sampling_iterator.py
+++ b/src/gflownet/data/sampling_iterator.py
@@ -412,7 +412,9 @@ class SQLiteLog:
         cur.close()
 
     def insert_many(self, rows, column_names):
-        assert all([type(x) is str or not isinstance(x, Iterable) for x in rows[0]]), "rows must only contain scalars"
+        assert all(
+            [isinstance(x, str) or not isinstance(x, Iterable) for x in rows[0]]
+        ), "rows must only contain scalars"
         if not self._has_results_table:
             self._make_results_table([type(i) for i in rows[0]], column_names)
         cur = self.db.cursor()

--- a/src/gflownet/data/sampling_iterator.py
+++ b/src/gflownet/data/sampling_iterator.py
@@ -177,12 +177,13 @@ class SamplingIterator(IterableDataset):
                 )
 
                 # Sample some dataset data
-                mols, flat_rewards = map(list, zip(*[self.data[i] for i in idcs])) if len(idcs) else ([], [])
+                graphs, flat_rewards = map(list, zip(*[self.data[i] for i in idcs])) if len(idcs) else ([], [])
                 flat_rewards = (
                     list(self.task.flat_reward_transform(torch.stack(flat_rewards))) if len(flat_rewards) else []
                 )
-                graphs = [self.ctx.mol_to_graph(m) for m in mols]
-                trajs = self.algo.create_training_data_from_graphs(graphs)
+                trajs = self.algo.create_training_data_from_graphs(
+                    graphs, self.model, cond_info["encoding"][:num_offline], 0
+                )
 
             else:  # If we're not sampling the conditionals, then the idcs refer to listed preferences
                 num_online = num_offline

--- a/src/gflownet/envs/frag_mol_env.py
+++ b/src/gflownet/envs/frag_mol_env.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 import rdkit.Chem as Chem
@@ -64,9 +64,10 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
         # The semantics of the SetEdgeAttr indices is that, for edge (u, v), we use the first half
         # for u and the second half for v. Each logit i in the first half for a given edge
         # corresponds to setting the stem atom of fragment u used to attach between u and v to be i
-        # (named f'{u}_attach') and vice versa for the second half and v, u.
+        # (named 'src_attach') and vice versa for the second half for v (named 'dst_attach').
         # Note to self: this choice results in a special case in generate_forward_trajectory for these
         # edge attributes. See PR#83 for details.
+        # Note to self: PR#XXX solves this issue by using src_attach/dst_attach as edge attributes
         self.num_edge_attr_logits = most_stems * 2
         # There are thus up to 2 edge attributes, the stem of u and the stem of v.
         self.num_edge_attrs = 2
@@ -75,6 +76,7 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
         self.num_cond_dim = num_cond_dim
         self.edges_are_duplicated = True
         self.edges_are_unordered = False
+        self.fail_on_missing_attr = True
 
         # Order in which models have to output logits
         self.action_type_order = [GraphActionType.Stop, GraphActionType.AddNode, GraphActionType.SetEdgeAttr]
@@ -112,17 +114,17 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
         elif t is GraphActionType.SetEdgeAttr:
             a, b = g.edge_index[:, act_row * 2]  # Edges are duplicated to get undirected GNN, deduplicated for logits
             if act_col < self.num_stem_acts:
-                attr = f"{int(a)}_attach"
+                attr = "src_attach"
                 val = act_col
             else:
-                attr = f"{int(b)}_attach"
+                attr = "dst_attach"
                 val = act_col - self.num_stem_acts
             return GraphAction(t, source=a.item(), target=b.item(), attr=attr, value=val)
         elif t is GraphActionType.RemoveNode:
             return GraphAction(t, source=act_row)
         elif t is GraphActionType.RemoveEdgeAttr:
             a, b = g.edge_index[:, act_row * 2]
-            attr = f"{int(a)}_attach" if act_col == 0 else f"{int(b)}_attach"
+            attr = "src_attach" if act_col == 0 else "dst_attach"
             return GraphAction(t, source=a.item(), target=b.item(), attr=attr)
 
     def GraphAction_to_aidx(self, g: gd.Data, action: GraphAction) -> Tuple[int, int, int]:
@@ -141,36 +143,36 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
              A triple describing the type of action, and the corresponding row and column index for
              the corresponding Categorical matrix.
         """
+        # Find the index of the action type, privileging the forward actions
+        for u in [self.action_type_order, self.bck_action_type_order]:
+            if action.action in u:
+                type_idx = u.index(action.action)
+                break
         if action.action is GraphActionType.Stop:
             row = col = 0
-            type_idx = self.action_type_order.index(action.action)
         elif action.action is GraphActionType.AddNode:
             row = action.source
             col = action.value
-            type_idx = self.action_type_order.index(action.action)
         elif action.action is GraphActionType.SetEdgeAttr:
             # Here the edges are duplicated, both (i,j) and (j,i) are in edge_index
             # so no need for a double check.
             row = (g.edge_index.T == torch.tensor([(action.source, action.target)])).prod(1).argmax()
             # Because edges are duplicated but logits aren't, divide by two
             row = row.div(2, rounding_mode="floor")  # type: ignore
-            if action.attr == f"{int(action.source)}_attach":
+            if action.attr == "src_attach":
                 col = action.value
             else:
                 col = action.value + self.num_stem_acts
-            type_idx = self.action_type_order.index(action.action)
         elif action.action is GraphActionType.RemoveNode:
             row = action.source
             col = 0
-            type_idx = self.bck_action_type_order.index(action.action)
         elif action.action is GraphActionType.RemoveEdgeAttr:
             row = (g.edge_index.T == torch.tensor([(action.source, action.target)])).prod(1).argmax()
             row = row.div(2, rounding_mode="floor")  # type: ignore
-            if action.attr == f"{int(action.source)}_attach":
+            if action.attr == "src_attach":
                 col = 0
             else:
                 col = 1
-            type_idx = self.bck_action_type_order.index(action.action)
         return (type_idx, int(row), int(col))
 
     def graph_to_Data(self, g: Graph) -> gd.Data:
@@ -216,8 +218,8 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
         has_unfilled_attach = False
         for i, e in enumerate(g.edges):
             ed = g.edges[e]
-            a = ed.get(f"{int(e[0])}_attach", -1)
-            b = ed.get(f"{int(e[1])}_attach", -1)
+            a = ed.get("src_attach", -1)
+            b = ed.get("dst_attach", -1)
             if a >= 0:
                 attached[e[0]].append(a)
                 remove_edge_attr_mask[i, 0] = 1
@@ -233,13 +235,15 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
         for i, e in enumerate(g.edges):
             ad = g.edges[e]
             for j, n in enumerate(e):
-                idx = ad.get(f"{int(n)}_attach", -1) + 1
+                attach_name = ["src_attach", "dst_attach"][j]
+                idx = ad.get(attach_name, -1) + 1
                 edge_attr[i * 2, idx + (self.num_stem_acts + 1) * j] = 1
                 edge_attr[i * 2 + 1, idx + (self.num_stem_acts + 1) * (1 - j)] = 1
-                if f"{int(n)}_attach" not in ad:
+                if attach_name not in ad:
                     for attach_point in range(max_degrees[n]):
                         if attach_point not in attached[n]:
                             set_edge_attr_mask[i, attach_point + self.num_stem_acts * j] = 1
+        # Since this is a DiGraph, make sure to put (i, j) first and (j, i) second
         edge_index = (
             torch.tensor([e for i, j in g.edges for e in [(i, j), (j, i)]], dtype=torch.long).reshape((-1, 2)).T
         )
@@ -308,9 +312,11 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
         for a, b in g.edges:
             afrag = g.nodes[a]["v"]
             bfrag = g.nodes[b]["v"]
+            if self.fail_on_missing_attr:
+                assert "src_attach" in g.edges[(a, b)] and "dst_attach" in g.edges[(a, b)]
             u, v = (
-                int(self.frags_stems[afrag][g.edges[(a, b)].get(f"{a}_attach", 0)] + offsets[a]),
-                int(self.frags_stems[bfrag][g.edges[(a, b)].get(f"{b}_attach", 0)] + offsets[b]),
+                int(self.frags_stems[afrag][g.edges[(a, b)].get("src_attach", 0)] + offsets[a]),
+                int(self.frags_stems[bfrag][g.edges[(a, b)].get("dst_attach", 0)] + offsets[b]),
             )
             bond_atoms += [u, v]
             mol.AddBond(u, v, Chem.BondType.SINGLE)

--- a/src/gflownet/envs/frag_mol_env.py
+++ b/src/gflownet/envs/frag_mol_env.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import numpy as np
 import rdkit.Chem as Chem
@@ -187,7 +187,7 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
         data:  gd.Data
             The corresponding torch_geometric object.
         """
-        zeros = lambda x: np.zeros(x, dtype=np.float32)
+        zeros = lambda x: np.zeros(x, dtype=np.float32)  # noqa: E731
         x = zeros((max(1, len(g.nodes)), self.num_node_dim))
         x[0, -1] = len(g.nodes) == 0
         edge_attr = zeros((len(g.edges) * 2, self.num_edge_dim))
@@ -373,8 +373,8 @@ def _recursive_decompose(ctx, m, all_matches, a2f, frags, bonds, max_depth=9, nu
         for fi, f in enumerate(frags):
             g.nodes[fi]["v"] = f
         for a, b, stemidx_a, stemidx_b, _, _ in bonds:
-            g.edges[(a, b)][f"src_attach"] = stemidx_a  # TODO: verify src/dst is correct?
-            g.edges[(a, b)][f"dst_attach"] = stemidx_b
+            g.edges[(a, b)]["src_attach"] = stemidx_a  # TODO: verify src/dst is correct?
+            g.edges[(a, b)]["dst_attach"] = stemidx_b
         m2 = ctx.graph_to_mol(g)
         if m2.HasSubstructMatch(m) and m.HasSubstructMatch(m2):
             return g
@@ -428,7 +428,7 @@ def _recursive_decompose(ctx, m, all_matches, a2f, frags, bonds, max_depth=9, nu
                         try:
                             # Make sure that fragment has that atom as a stem atom
                             other_frag_stemidx = ctx.frags_stems[frags[other_frag_idx]].index(other_frag_atomidx)
-                        except ValueError as e:
+                        except ValueError:
                             continue
                         # Make sure that that fragment's stem atom isn't already used
                         for b in bonds + possible_bonds:

--- a/src/gflownet/envs/frag_mol_env.py
+++ b/src/gflownet/envs/frag_mol_env.py
@@ -356,10 +356,10 @@ def _recursive_decompose(ctx, m, all_matches, a2f, frags, bonds, max_depth=9, nu
         # graph is a tree, e = n - 1
         if len(bonds) != len(frags) - 1:
             return None
-        g = nx.Graph()
+        g = Graph()
         g.add_nodes_from(range(len(frags)))
         g.add_edges_from([(i[0], i[1]) for i in bonds])
-        assert nx.is_connected(g), "Somehow we got here but fragments dont connect?"
+        # assert nx.is_connected(g), "Somehow we got here but fragments dont connect?"
         for fi, f in enumerate(frags):
             g.nodes[fi]["v"] = f
         for a, b, stemidx_a, stemidx_b, _, _ in bonds:

--- a/src/gflownet/envs/frag_mol_env.py
+++ b/src/gflownet/envs/frag_mol_env.py
@@ -83,6 +83,7 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
             GraphActionType.RemoveEdgeAttr,
         ]
         self.device = torch.device("cpu")
+        self.sorted_frags = sorted(list(enumerate(self.frags_mol)), key=lambda x: -x[1].GetNumAtoms())
 
     def aidx_to_GraphAction(self, g: gd.Data, action_idx: Tuple[int, int, int], fwd: bool = True):
         """Translate an action index (e.g. from a GraphActionCategorical) to a GraphAction
@@ -275,7 +276,11 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
 
     def mol_to_graph(self, mol):
         """Convert an RDMol to a Graph"""
-        raise NotImplementedError()
+        assert type(mol) is Chem.Mol
+        all_matches = {}
+        for fragidx, frag in self.sorted_frags:
+            all_matches[fragidx] = mol.GetSubstructMatches(frag, uniquify=False)
+        return _recursive_decompose(self, mol, all_matches, {}, [], [], 9)
 
     def graph_to_mol(self, g: Graph) -> Chem.Mol:
         """Convert a Graph to an RDKit molecule
@@ -331,3 +336,101 @@ class FragMolBuildingEnvContext(GraphBuildingEnvContext):
         if mol is None:
             return False
         return True
+
+
+def _recursive_decompose(ctx, m, all_matches, a2f, frags, bonds, max_depth=9, numiters=None):
+    if numiters is None:
+        numiters = [0]
+    numiters[0] += 1
+    if numiters[0] > 1_000:
+        raise ValueError("too many iterations")
+    if max_depth == 0 or len(a2f) == m.GetNumAtoms():
+        # try to make a mol, does it work?
+        # Did we match all the atoms?
+        if len(a2f) < m.GetNumAtoms():
+            return None
+        # graph is a tree, e = n - 1
+        if len(bonds) != len(frags) - 1:
+            return None
+        g = nx.Graph()
+        g.add_nodes_from(range(len(frags)))
+        g.add_edges_from([(i[0], i[1]) for i in bonds])
+        assert nx.is_connected(g), "Somehow we got here but fragments dont connect?"
+        for fi, f in enumerate(frags):
+            g.nodes[fi]["v"] = f
+        for a, b, stemidx_a, stemidx_b, _, _ in bonds:
+            g.edges[(a, b)][f"{a}_attach"] = stemidx_a
+            g.edges[(a, b)][f"{b}_attach"] = stemidx_b
+        m2 = ctx.graph_to_mol(g)
+        if m2.HasSubstructMatch(m) and m.HasSubstructMatch(m2):
+            return g
+        return None
+    for fragidx, frag in ctx.sorted_frags:
+        # Some fragments have symmetric versions, so we need all matches up to isomorphism!
+        matches = all_matches[fragidx]
+        for match in matches:
+            if any(i in a2f for i in match):
+                continue
+            # Verify that atoms actually have the same charge
+            if any(
+                frag.GetAtomWithIdx(ai).GetFormalCharge() != m.GetAtomWithIdx(bi).GetFormalCharge()
+                for ai, bi in enumerate(match)
+            ):
+                continue
+            new_frag_idx = len(frags)
+            new_frags = frags + [fragidx]
+            new_a2f = {**a2f, **{i: (fi, new_frag_idx) for fi, i in enumerate(match)}}
+            possible_bonds = []
+            is_valid_match = True
+            # Is every atom that has a bond outside of this fragment also a stem atom?
+            for fi, i in enumerate(match):
+                for j in m.GetAtomWithIdx(i).GetNeighbors():
+                    j = j.GetIdx()
+                    if j in match:
+                        continue
+                    # There should only be single bonds between fragments
+                    if m.GetBondBetweenAtoms(i, j).GetBondType() != Chem.BondType.SINGLE:
+                        is_valid_match = False
+                        break
+                    # At this point, we know (i, j) is a single bond that goes outside the fragment
+                    # so we check if the fragment we chose has that atom as a stem atom
+                    if fi not in ctx.frags_stems[fragidx]:
+                        is_valid_match = False
+                        break
+                if not is_valid_match:
+                    break
+            if not is_valid_match:
+                continue
+            for this_frag_stemidx, i in enumerate([match[s] for s in ctx.frags_stems[fragidx]]):
+                for j in m.GetAtomWithIdx(i).GetNeighbors():
+                    j = j.GetIdx()
+                    if j in match:
+                        continue
+                    if m.GetBondBetweenAtoms(i, j).GetBondType() != Chem.BondType.SINGLE:
+                        continue
+                    # Make sure the neighbor is part of an already identified fragment
+                    if j in a2f and a2f[j] != new_frag_idx:
+                        other_frag_atomidx, other_frag_idx = a2f[j]
+                        try:
+                            # Make sure that fragment has that atom as a stem atom
+                            other_frag_stemidx = ctx.frags_stems[frags[other_frag_idx]].index(other_frag_atomidx)
+                        except ValueError as e:
+                            continue
+                        # Make sure that that fragment's stem atom isn't already used
+                        for b in bonds + possible_bonds:
+                            if b[0] == other_frag_idx and b[2] == other_frag_stemidx:
+                                break
+                            if b[1] == other_frag_idx and b[3] == other_frag_stemidx:
+                                break
+                            if b[0] == new_frag_idx and b[2] == this_frag_stemidx:
+                                break
+                            if b[1] == new_frag_idx and b[3] == this_frag_stemidx:
+                                break
+                        else:
+                            possible_bonds.append(
+                                (other_frag_idx, new_frag_idx, other_frag_stemidx, this_frag_stemidx, i, j)
+                            )
+            new_bonds = bonds + possible_bonds
+            dec = _recursive_decompose(ctx, m, all_matches, new_a2f, new_frags, new_bonds, max_depth - 1, numiters)
+            if dec:
+                return dec

--- a/src/gflownet/envs/graph_building_env.py
+++ b/src/gflownet/envs/graph_building_env.py
@@ -606,7 +606,7 @@ class GraphActionCategorical:
         # there are no corresponding logits (this can happen if e.g. a
         # graph has no edges), we don't want to accidentally take the
         # max of that type, since we'd get 0.
-        min_val = torch.min(torch.stack([i.min() for i in x if i.numel()]))
+        min_val = torch.finfo().min
         outs = [torch.zeros(self.num_graphs, i.shape[1], device=self.dev) + min_val for i in x]
         maxl = [scatter_max(i, b, dim=0, out=out) for i, b, out in zip(x, batch, outs)]
         if reduce_columns:

--- a/src/gflownet/envs/graph_building_env.py
+++ b/src/gflownet/envs/graph_building_env.py
@@ -16,12 +16,17 @@ from torch_scatter import scatter, scatter_max
 
 
 class Graph(nx.Graph):
-    # Subclassing nx.Graph for debugging purposes
     def __str__(self):
         return repr(self)
 
     def __repr__(self):
         return f'<{list(self.nodes)}, {list(self.edges)}, {list(self.nodes[i]["v"] for i in self.nodes)}>'
+
+    def bridges(self):
+        return list(nx.bridges(self))
+
+    def relabel_nodes(self, rmap):
+        return nx.relabel_nodes(self, rmap)
 
 
 def graph_without_edge(g, e):
@@ -325,6 +330,32 @@ class GraphBuildingEnv:
             return GraphAction(GraphActionType.RemoveNodeAttr, source=ga.source, attr=ga.attr)
         if ga.action == GraphActionType.SetEdgeAttr:
             return GraphAction(GraphActionType.RemoveEdgeAttr, source=ga.source, target=ga.target, attr=ga.attr)
+        if ga.action == GraphActionType.RemoveNode:
+            # TODO: implement neighbors or something?
+            # neighbors = list(g.neighbors(ga.source))
+            # source = 0 if not len(neighbors) else neighbors[0]
+            neighbors = [i for i in g.edges if i[0] == ga.source or i[1] == ga.source]
+            assert len(neighbors) <= 1  # RemoveNode should only be a legal action if the node has one or zero neighbors
+            source = 0 if not len(neighbors) else neighbors[0][0] if neighbors[0][0] != ga.source else neighbors[0][1]
+            return GraphAction(GraphActionType.AddNode, source=source, value=g.nodes[ga.source]["v"])
+        if ga.action == GraphActionType.RemoveEdge:
+            return GraphAction(GraphActionType.AddEdge, source=ga.source, target=ga.target)
+        if ga.action == GraphActionType.RemoveNodeAttr:
+            return GraphAction(
+                GraphActionType.SetNodeAttr,
+                source=ga.source,
+                target=ga.target,
+                attr=ga.attr,
+                value=g.nodes[ga.source][ga.attr],
+            )
+        if ga.action == GraphActionType.RemoveEdgeAttr:
+            return GraphAction(
+                GraphActionType.SetEdgeAttr,
+                source=ga.source,
+                target=ga.target,
+                attr=ga.attr,
+                value=g.edges[ga.source, ga.target][ga.attr],
+            )
 
 
 def generate_forward_trajectory(g: Graph, max_nodes: int = None) -> List[Tuple[Graph, GraphAction]]:

--- a/src/gflownet/envs/graph_building_env.py
+++ b/src/gflownet/envs/graph_building_env.py
@@ -322,15 +322,15 @@ class GraphBuildingEnv:
     def reverse(self, g: Graph, ga: GraphAction):
         if ga.action == GraphActionType.Stop:
             return ga
-        if ga.action == GraphActionType.AddNode:
+        elif ga.action == GraphActionType.AddNode:
             return GraphAction(GraphActionType.RemoveNode, source=len(g.nodes))
-        if ga.action == GraphActionType.AddEdge:
+        elif ga.action == GraphActionType.AddEdge:
             return GraphAction(GraphActionType.RemoveEdge, source=ga.source, target=ga.target)
-        if ga.action == GraphActionType.SetNodeAttr:
+        elif ga.action == GraphActionType.SetNodeAttr:
             return GraphAction(GraphActionType.RemoveNodeAttr, source=ga.source, attr=ga.attr)
-        if ga.action == GraphActionType.SetEdgeAttr:
+        elif ga.action == GraphActionType.SetEdgeAttr:
             return GraphAction(GraphActionType.RemoveEdgeAttr, source=ga.source, target=ga.target, attr=ga.attr)
-        if ga.action == GraphActionType.RemoveNode:
+        elif ga.action == GraphActionType.RemoveNode:
             # TODO: implement neighbors or something?
             # neighbors = list(g.neighbors(ga.source))
             # source = 0 if not len(neighbors) else neighbors[0]
@@ -338,9 +338,9 @@ class GraphBuildingEnv:
             assert len(neighbors) <= 1  # RemoveNode should only be a legal action if the node has one or zero neighbors
             source = 0 if not len(neighbors) else neighbors[0][0] if neighbors[0][0] != ga.source else neighbors[0][1]
             return GraphAction(GraphActionType.AddNode, source=source, value=g.nodes[ga.source]["v"])
-        if ga.action == GraphActionType.RemoveEdge:
+        elif ga.action == GraphActionType.RemoveEdge:
             return GraphAction(GraphActionType.AddEdge, source=ga.source, target=ga.target)
-        if ga.action == GraphActionType.RemoveNodeAttr:
+        elif ga.action == GraphActionType.RemoveNodeAttr:
             return GraphAction(
                 GraphActionType.SetNodeAttr,
                 source=ga.source,
@@ -348,7 +348,7 @@ class GraphBuildingEnv:
                 attr=ga.attr,
                 value=g.nodes[ga.source][ga.attr],
             )
-        if ga.action == GraphActionType.RemoveEdgeAttr:
+        elif ga.action == GraphActionType.RemoveEdgeAttr:
             return GraphAction(
                 GraphActionType.SetEdgeAttr,
                 source=ga.source,
@@ -356,6 +356,8 @@ class GraphBuildingEnv:
                 attr=ga.attr,
                 value=g.edges[ga.source, ga.target][ga.attr],
             )
+        else:
+            raise ValueError(f"Unknown action type {ga.action}", ga.action)
 
 
 def generate_forward_trajectory(g: Graph, max_nodes: int = None) -> List[Tuple[Graph, GraphAction]]:

--- a/src/gflownet/tasks/seh_frag.py
+++ b/src/gflownet/tasks/seh_frag.py
@@ -13,7 +13,7 @@ from torch import Tensor
 from torch.utils.data import Dataset
 
 from gflownet.config import Config
-from gflownet.envs.frag_mol_env import FragMolBuildingEnvContext
+from gflownet.envs.frag_mol_env import FragMolBuildingEnvContext, Graph
 from gflownet.models import bengio2021flow
 from gflownet.online_trainer import StandardOnlineTrainer
 from gflownet.trainer import FlatRewards, GFNTask, RewardScalar
@@ -110,8 +110,8 @@ class LittleSEHDataset(Dataset):
 
     def __init__(self) -> None:
         super().__init__()
-        self.props = []
-        self.mols = []
+        self.props: List[Tensor] = []
+        self.mols: List[Graph] = []
 
     def setup(self, task, ctx):
         rdmols = [Chem.MolFromSmiles(i) for i in SOME_MOLS]

--- a/src/gflownet/tasks/seh_frag.py
+++ b/src/gflownet/tasks/seh_frag.py
@@ -194,7 +194,7 @@ def main():
         "opt": {
             "lr_decay": 20000,
         },
-        "algo": {"sampling_tau": 0.99, "offline_ratio": 0.0},
+        "algo": {"sampling_tau": 0.99, "offline_ratio": 0.25},
         "cond": {
             "temperature": {
                 "sample_dist": "uniform",

--- a/src/gflownet/tasks/seh_frag.py
+++ b/src/gflownet/tasks/seh_frag.py
@@ -194,7 +194,7 @@ def main():
         "opt": {
             "lr_decay": 20000,
         },
-        "algo": {"sampling_tau": 0.99, "offline_ratio": 0.25},
+        "algo": {"sampling_tau": 0.99, "offline_ratio": 0.0},
         "cond": {
             "temperature": {
                 "sample_dist": "uniform",

--- a/src/gflownet/tasks/seh_frag.py
+++ b/src/gflownet/tasks/seh_frag.py
@@ -190,11 +190,11 @@ def main():
         "device": "cuda" if torch.cuda.is_available() else "cpu",
         "overwrite_existing_exp": True,
         "num_training_steps": 10_000,
-        "num_workers": 0,
+        "num_workers": 8,
         "opt": {
             "lr_decay": 20000,
         },
-        "algo": {"sampling_tau": 0.99, "offline_ratio": 0.25},
+        "algo": {"sampling_tau": 0.99, "offline_ratio": 0.0},
         "cond": {
             "temperature": {
                 "sample_dist": "uniform",

--- a/src/gflownet/tasks/seh_frag_moo.py
+++ b/src/gflownet/tasks/seh_frag_moo.py
@@ -265,14 +265,14 @@ class SEHMOOFragTrainer(SEHFragTrainer):
         if not (
             tcfg.focus_type is None
             or tcfg.focus_type == "centered"
-            or (type(tcfg.focus_type) is list and len(tcfg.focus_type) == 1)
+            or (isinstance(tcfg.focus_type, list) and len(tcfg.focus_type) == 1)
         ):
             assert tcfg.preference_type is None, (
                 f"Cannot use preferences with multiple focus regions, here focus_type={tcfg.focus_type} "
                 f"and preference_type={tcfg.preference_type}"
             )
 
-        if type(tcfg.focus_type) is list and len(tcfg.focus_type) > 1:
+        if isinstance(tcfg.focus_type, list) and len(tcfg.focus_type) > 1:
             n_valid = len(tcfg.focus_type)
         else:
             n_valid = tcfg.n_valid

--- a/src/gflownet/utils/conditioning.py
+++ b/src/gflownet/utils/conditioning.py
@@ -53,7 +53,7 @@ class TemperatureConditional(Conditional):
         cfg = self.cfg.cond.temperature
         beta = None
         if cfg.sample_dist == "constant":
-            assert type(cfg.dist_params[0]) is float
+            assert isinstance(cfg.dist_params[0], float)
             beta = np.array(cfg.dist_params[0]).repeat(n).astype(np.float32)
             beta_enc = torch.zeros((n, cfg.num_thermometer_dim))
         else:
@@ -174,7 +174,7 @@ class FocusRegionConditional(Conditional):
         elif self.cfg.focus_type in ["hyperspherical", "learned-tabular"]:
             valid_focus_dirs = metrics.partition_hypersphere(d=self.n_objectives, k=self.n_valid, normalisation="l2")
             self.fixed_focus_dirs = None
-        elif type(self.cfg.focus_type) is list:
+        elif isinstance(self.cfg.focus_type, list):
             if len(self.cfg.focus_type) == 1:
                 valid_focus_dirs = np.array([self.cfg.focus_type[0]] * self.n_valid)
                 self.fixed_focus_dirs = valid_focus_dirs

--- a/src/gflownet/utils/multiprocessing_proxy.py
+++ b/src/gflownet/utils/multiprocessing_proxy.py
@@ -22,8 +22,12 @@ class MPObjectPlaceholder:
         if self._is_init:
             return
         info = torch.utils.data.get_worker_info()
-        self.in_queue = self.qs[0][info.id]
-        self.out_queue = self.qs[1][info.id]
+        if info is None:
+            self.in_queue = self.qs[0][-1]
+            self.out_queue = self.qs[1][-1]
+        else:
+            self.in_queue = self.qs[0][info.id]
+            self.out_queue = self.qs[1][info.id]
         self._is_init = True
 
     def encode(self, m):
@@ -88,8 +92,8 @@ class MPObjectProxy:
             memory, but increases load on CPU. It is recommended to activate this flag if
             encountering "Too many open files"-type errors.
         """
-        self.in_queues = [mp.Queue() for i in range(num_workers)]  # type: ignore
-        self.out_queues = [mp.Queue() for i in range(num_workers)]  # type: ignore
+        self.in_queues = [mp.Queue() for i in range(num_workers + 1)]  # type: ignore
+        self.out_queues = [mp.Queue() for i in range(num_workers + 1)]  # type: ignore
         self.pickle_messages = pickle_messages
         self.placeholder = MPObjectPlaceholder(self.in_queues, self.out_queues, pickle_messages)
         self.obj = obj


### PR DESCRIPTION
This PR adds proper backward sampling routines, specifically to sample from parameterized backward policies or to sample uniformly (from masks).

This PR also:
- Changes how stem attachments are defined in the fragment environment using a saner "src_"/"dst_" format
- Includes #96 to showcase offline training
- adds an extra `Queue` object for in-main-process calls to an MP wrapped model
- changes `GraphActionCategorical._compute_batchwise_max` to use `finfo().min` instead of the batch min to compute the argmax -- this avoids some edge case errors.
- numpy-fies `graph_to_Data` in the fragment environment

Includes @diamondspark as an author since the PR is based on his implementation.