### PR TITLE
Fixes GPU memory overflow when using replay buffer

### DIFF
--- a/src/gflownet/algo/config.py
+++ b/src/gflownet/algo/config.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import Optional
 
+from gflownet.utils.misc import StrictDataClass
+
 
 class Backward(IntEnum):
     """
@@ -53,7 +55,7 @@ class LossFN(IntEnum):
 
 
 @dataclass
-class TBConfig:
+class TBConfig(StrictDataClass):
     """Trajectory Balance config.
 
     Attributes
@@ -113,7 +115,7 @@ class TBConfig:
 
 
 @dataclass
-class MOQLConfig:
+class MOQLConfig(StrictDataClass):
     gamma: float = 1
     num_omega_samples: int = 32
     num_objectives: int = 2
@@ -122,14 +124,14 @@ class MOQLConfig:
 
 
 @dataclass
-class A2CConfig:
+class A2CConfig(StrictDataClass):
     entropy: float = 0.01
     gamma: float = 1
     penalty: float = -10
 
 
 @dataclass
-class FMConfig:
+class FMConfig(StrictDataClass):
     epsilon: float = 1e-38
     balanced_loss: bool = False
     leaf_coef: float = 10
@@ -137,14 +139,14 @@ class FMConfig:
 
 
 @dataclass
-class SQLConfig:
+class SQLConfig(StrictDataClass):
     alpha: float = 0.01
     gamma: float = 1
     penalty: float = -10
 
 
 @dataclass
-class AlgoConfig:
+class AlgoConfig(StrictDataClass):
     """Generic configuration for algorithms
 
     Attributes

--- a/src/gflownet/config.py
+++ b/src/gflownet/config.py
@@ -8,10 +8,11 @@ from gflownet.data.config import ReplayConfig
 from gflownet.models.config import ModelConfig
 from gflownet.tasks.config import TasksConfig
 from gflownet.utils.config import ConditionalsConfig
+from gflownet.utils.misc import StrictDataClass
 
 
 @dataclass
-class OptimizerConfig:
+class OptimizerConfig(StrictDataClass):
     """Generic configuration for optimizers
 
     Attributes
@@ -45,7 +46,7 @@ class OptimizerConfig:
 
 
 @dataclass
-class Config:
+class Config(StrictDataClass):
     """Base configuration for training
 
     Attributes

--- a/src/gflownet/data/config.py
+++ b/src/gflownet/data/config.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from gflownet.utils.misc import StrictDataClass
+
 
 @dataclass
-class ReplayConfig:
+class ReplayConfig(StrictDataClass):
     """Replay buffer configuration
 
     Attributes

--- a/src/gflownet/data/data_source.py
+++ b/src/gflownet/data/data_source.py
@@ -7,7 +7,7 @@ from torch.utils.data import IterableDataset
 
 from gflownet import GFNAlgorithm, GFNTask
 from gflownet.config import Config
-from gflownet.data.replay_buffer import ReplayBuffer
+from gflownet.data.replay_buffer import ReplayBuffer, detach_and_cpu
 from gflownet.envs.graph_building_env import GraphBuildingEnvContext
 from gflownet.utils.misc import get_worker_rng
 
@@ -214,6 +214,7 @@ class DataSource(IterableDataset):
         return batch_info
 
     def create_batch(self, trajs, batch_info):
+        trajs = detach_and_cpu(trajs)
         ci = torch.stack([t["cond_info"]["encoding"] for t in trajs])
         log_rewards = torch.stack([t["log_reward"] for t in trajs])
         batch = self.algo.construct_batch(trajs, ci, log_rewards)

--- a/src/gflownet/data/data_source.py
+++ b/src/gflownet/data/data_source.py
@@ -221,10 +221,10 @@ class DataSource(IterableDataset):
         batch.num_online = sum(t.get("is_online", 0) for t in trajs)
         batch.num_offline = len(trajs) - batch.num_online
         batch.extra_info = batch_info
-        if "preferences" in trajs[0]:
-            batch.preferences = torch.stack([t["preferences"] for t in trajs])
-        if "focus_dir" in trajs[0]:
-            batch.focus_dir = torch.stack([t["focus_dir"] for t in trajs])
+        if "preferences" in trajs[0]['cond_info'].keys():
+            batch.preferences = torch.stack([t['cond_info']["preferences"] for t in trajs])
+        if "focus_dir" in trajs[0]['cond_info'].keys():
+            batch.focus_dir = torch.stack([t['cond_info']["focus_dir"] for t in trajs])
 
         if self.ctx.has_n() and self.cfg.algo.tb.do_predict_n:
             log_ns = [self.ctx.traj_log_n(i["traj"]) for i in trajs]

--- a/src/gflownet/data/data_source.py
+++ b/src/gflownet/data/data_source.py
@@ -221,10 +221,10 @@ class DataSource(IterableDataset):
         batch.num_online = sum(t.get("is_online", 0) for t in trajs)
         batch.num_offline = len(trajs) - batch.num_online
         batch.extra_info = batch_info
-        if "preferences" in trajs[0]['cond_info'].keys():
-            batch.preferences = torch.stack([t['cond_info']["preferences"] for t in trajs])
-        if "focus_dir" in trajs[0]['cond_info'].keys():
-            batch.focus_dir = torch.stack([t['cond_info']["focus_dir"] for t in trajs])
+        if "preferences" in trajs[0]["cond_info"].keys():
+            batch.preferences = torch.stack([t["cond_info"]["preferences"] for t in trajs])
+        if "focus_dir" in trajs[0]["cond_info"].keys():
+            batch.focus_dir = torch.stack([t["cond_info"]["focus_dir"] for t in trajs])
 
         if self.ctx.has_n() and self.cfg.algo.tb.do_predict_n:
             log_ns = [self.ctx.traj_log_n(i["traj"]) for i in trajs]

--- a/src/gflownet/data/replay_buffer.py
+++ b/src/gflownet/data/replay_buffer.py
@@ -8,6 +8,10 @@ from gflownet.config import Config
 
 class ReplayBuffer(object):
     def __init__(self, cfg: Config, rng: np.random.Generator = None):
+        """
+        Replay buffer for storing and sampling arbitrary data (e.g. transitions or trajectories)
+        In self.push(), the buffer detaches any torch tensor and sends it to the CPU.
+        """
         self.capacity = cfg.replay.capacity
         self.warmup = cfg.replay.warmup
         assert self.warmup <= self.capacity, "ReplayBuffer warmup must be smaller than capacity"
@@ -23,6 +27,7 @@ class ReplayBuffer(object):
             assert self._input_size == len(args), "ReplayBuffer input size must be constant"
         if len(self.buffer) < self.capacity:
             self.buffer.append(None)
+        args = detach_and_cpu(list(args))
         self.buffer[self.position] = args
         self.position = (self.position + 1) % self.capacity
 
@@ -42,3 +47,15 @@ class ReplayBuffer(object):
 
     def __len__(self):
         return len(self.buffer)
+
+
+def detach_and_cpu(x):
+    if isinstance(x, torch.Tensor):
+        x = x.detach().cpu()
+    elif isinstance(x, dict):
+        for k in x.keys():
+            x[k] = detach_and_cpu(x[k])
+    elif isinstance(x, list):
+        for i in range(len(x)):
+            x[i] = detach_and_cpu(x[i])
+    return x

--- a/src/gflownet/data/replay_buffer.py
+++ b/src/gflownet/data/replay_buffer.py
@@ -27,7 +27,7 @@ class ReplayBuffer(object):
             assert self._input_size == len(args), "ReplayBuffer input size must be constant"
         if len(self.buffer) < self.capacity:
             self.buffer.append(None)
-        args = detach_and_cpu(list(args))
+        args = detach_and_cpu(args)
         self.buffer[self.position] = args
         self.position = (self.position + 1) % self.capacity
 

--- a/src/gflownet/data/replay_buffer.py
+++ b/src/gflownet/data/replay_buffer.py
@@ -53,9 +53,9 @@ def detach_and_cpu(x):
     if isinstance(x, torch.Tensor):
         x = x.detach().cpu()
     elif isinstance(x, dict):
-        for k in x.keys():
-            x[k] = detach_and_cpu(x[k])
+        x = {k: detach_and_cpu(v) for k, v in x.items()}
     elif isinstance(x, list):
-        for i in range(len(x)):
-            x[i] = detach_and_cpu(x[i])
+        x = [detach_and_cpu(v) for v in x]
+    elif isinstance(x, tuple):
+        x = tuple(detach_and_cpu(v) for v in x)
     return x

--- a/src/gflownet/models/config.py
+++ b/src/gflownet/models/config.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass, field
 from enum import Enum
 
+from gflownet.utils.misc import StrictDataClass
+
 
 @dataclass
-class GraphTransformerConfig:
+class GraphTransformerConfig(StrictDataClass):
     num_heads: int = 2
     ln_type: str = "pre"
     num_mlp_layers: int = 0
@@ -15,13 +17,13 @@ class SeqPosEnc(int, Enum):
 
 
 @dataclass
-class SeqTransformerConfig:
+class SeqTransformerConfig(StrictDataClass):
     num_heads: int = 2
     posenc: SeqPosEnc = SeqPosEnc.Rotary
 
 
 @dataclass
-class ModelConfig:
+class ModelConfig(StrictDataClass):
     """Generic configuration for models
 
     Attributes

--- a/src/gflownet/tasks/config.py
+++ b/src/gflownet/tasks/config.py
@@ -1,14 +1,16 @@
 from dataclasses import dataclass, field
 from typing import List
 
+from gflownet.utils.misc import StrictDataClass
+
 
 @dataclass
-class SEHTaskConfig:
+class SEHTaskConfig(StrictDataClass):
     reduced_frag: bool = False
 
 
 @dataclass
-class SEHMOOTaskConfig:
+class SEHMOOTaskConfig(StrictDataClass):
     """Config for the SEHMOOTask
 
     Attributes
@@ -31,13 +33,13 @@ class SEHMOOTaskConfig:
 
 
 @dataclass
-class QM9TaskConfig:
+class QM9TaskConfig(StrictDataClass):
     h5_path: str = "./data/qm9/qm9.h5"  # see src/gflownet/data/qm9.py
     model_path: str = "./data/qm9/qm9_model.pt"
 
 
 @dataclass
-class QM9MOOTaskConfig:
+class QM9MOOTaskConfig(StrictDataClass):
     """
     Config for the QM9MooTask
 
@@ -61,7 +63,7 @@ class QM9MOOTaskConfig:
 
 
 @dataclass
-class TasksConfig:
+class TasksConfig(StrictDataClass):
     qm9: QM9TaskConfig = field(default_factory=QM9TaskConfig)
     qm9_moo: QM9MOOTaskConfig = field(default_factory=QM9MOOTaskConfig)
     seh: SEHTaskConfig = field(default_factory=SEHTaskConfig)

--- a/src/gflownet/utils/config.py
+++ b/src/gflownet/utils/config.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
+from gflownet.utils.misc import StrictDataClass
+
 
 @dataclass
-class TempCondConfig:
+class TempCondConfig(StrictDataClass):
     """Config for the temperature conditional.
 
     Attributes
@@ -28,13 +30,13 @@ class TempCondConfig:
 
 
 @dataclass
-class MultiObjectiveConfig:
+class MultiObjectiveConfig(StrictDataClass):
     num_objectives: int = 2  # TODO: Change that as it can conflict with cfg.task.seh_moo.num_objectives
     num_thermometer_dim: int = 16
 
 
 @dataclass
-class WeightedPreferencesConfig:
+class WeightedPreferencesConfig(StrictDataClass):
     """Config for the weighted preferences conditional.
 
     Attributes
@@ -51,7 +53,7 @@ class WeightedPreferencesConfig:
 
 
 @dataclass
-class FocusRegionConfig:
+class FocusRegionConfig(StrictDataClass):
     """Config for the focus region conditional.
 
     Attributes
@@ -71,7 +73,7 @@ class FocusRegionConfig:
 
 
 @dataclass
-class ConditionalsConfig:
+class ConditionalsConfig(StrictDataClass):
     valid_sample_cond_info: bool = True
     temperature: TempCondConfig = field(default_factory=TempCondConfig)
     moo: MultiObjectiveConfig = field(default_factory=MultiObjectiveConfig)

--- a/src/gflownet/utils/misc.py
+++ b/src/gflownet/utils/misc.py
@@ -65,4 +65,8 @@ class StrictDataClass:
         if hasattr(self, name) or name in self.__annotations__:
             super().__setattr__(name, value)
         else:
-            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'."
+                f" '{type(self).__name__}' is a StrictDataClass object."
+                f" Attributes can only be defined in the class definition."
+            )

--- a/src/gflownet/utils/misc.py
+++ b/src/gflownet/utils/misc.py
@@ -54,3 +54,15 @@ def set_main_process_device(device):
 def get_worker_device():
     worker_info = torch.utils.data.get_worker_info()
     return _main_process_device[0] if worker_info is None else torch.device("cpu")
+
+
+class StrictDataClass:
+    """
+    A dataclass that raises an error if any field is created outside of the __init__ method.
+    """
+
+    def __setattr__(self, name, value):
+        if hasattr(self, name) or name in self.__annotations__:
+            super().__setattr__(name, value)
+        else:
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")


### PR DESCRIPTION
With `config.replay.use = True`, we get the following error:

> torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 80.00 MiB. GPU 0 has a total capacty of 79.15 GiB of which 63.25 MiB is free. Including non-PyTorch memory, this process has 79.08 GiB memory in use. Of the allocated memory 78.38 GiB is allocated by PyTorch, and 196.30 MiB is reserved by PyTorch but unallocated.

This was likely introduced in [PR#122](https://github.com/recursionpharma/gflownet/commit/9bf35cdaa636ff47fc5306bab9251b748cbff80f) as it does not occur when going back to [commit a8768ee](https://github.com/recursionpharma/gflownet/commit/a8768ee4a1131f749031f8ef10ca4eb2c6c7b9af) (PR#121). It only occurs when using the replay buffer. This PR fixes the issue by simply detaching and sending to CPU every tensor getting pushed into the replay buffer.

To reproduce the error:

```
REPLAY = True
N_STEPS = 80_000
OBJECTIVES = ["seh", "qed", "sa", "mw"]
FOCUS_TYPE = "dirichlet"
PREF_TYPE = None

config.num_workers = 0
config.seed = 0
config.print_every = 100
config.validate_every = 100
config.num_final_gen_steps = 100
config.num_training_steps = N_STEPS
config.pickle_mp_messages = True
config.overwrite_existing_exp = True
config.opt.learning_rate = 1e-4
config.opt.lr_decay = 20_000
config.algo.method = "TB"
config.algo.sampling_tau = 0.95
config.algo.train_random_action_prob = 0.01
config.algo.tb.Z_learning_rate = 1e-3
config.algo.tb.Z_lr_decay = 50_000
config.model.num_layers = 2
config.model.num_emb = 256
config.task.seh_moo.objectives = OBJECTIVES
config.task.seh_moo.n_valid = 15
config.task.seh_moo.n_valid_repeats = 128
config.cond.temperature.sample_dist = "constant"
config.cond.temperature.dist_params = [60.0]
config.cond.weighted_prefs.preference_type = PREF_TYPE
config.cond.focus_region.focus_type = FOCUS_TYPE
config.cond.focus_region.focus_cosim = 0.98
config.cond.focus_region.focus_limit_coef = 0.20
config.cond.focus_region.focus_model_training_limits = (0.25, 0.75)
config.cond.focus_region.focus_model_state_space_res = 30
config.cond.focus_region.max_train_it = 5_000
config.replay.use = REPLAY
config.replay.warmup = 1000
config.replay.hindsight_ratio = 0.3
config.replay.capacity = 100_000

trial = SEHMOOFragTrainer(config)
trial.run()
```