### PR TITLE
Add `raw_logits` in GraphActionCategorical to() method

### DIFF
--- a/src/gflownet/envs/graph_building_env.py
+++ b/src/gflownet/envs/graph_building_env.py
@@ -627,6 +627,7 @@ class GraphActionCategorical:
 
     def to(self, device):
         self.dev = device
+        self.raw_logits = [i.to(device) for i in self.raw_logits]
         self._masked_logits = [i.to(device) for i in self._masked_logits]
         self.batch = [i.to(device) for i in self.batch]
         self.slice = [i.to(device) for i in self.slice]


### PR DESCRIPTION
`raw_logits` were not sent to the device, causing downstream errors depending on when the raw logits are used to compute the masked logits.