### PR TITLE
chore: switch sourcing Python packages from Nexus to GAR

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM gcr.io/eng-infrastructure/rxrx-pyenv as test
+FROM us-central1-docker.pkg.dev/eng-ops-b1bb36c9/container-images/rxrx-pyenv:v2025.03.01 as test
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py3{10}, report
+requires = keyrings.google-artifactregistry-auth
 
 [testenv]
 commands = pytest
@@ -12,7 +13,7 @@ install_command =
     python -m pip install -U {opts} {packages} --find-links https://data.pyg.org/whl/torch-2.1.2+cpu.html
 deps =
     py310: -r requirements/dev-3.10.txt
-
+passenv = GOOGLE_APPLICATION_CREDENTIALS
 
 [testenv:report]
 deps = coverage
@@ -32,3 +33,4 @@ deps =
     black
 skip_install = true
 commands = pre-commit run --all-files --show-diff-on-failure
+


### PR DESCRIPTION
update from `legion` on behalf of @dmaljovec

# What?
 - Switch from Nexus to Google Artifact Registry for installing dependencies in test environments for this project
# Why?
 - We are trying to deprecate usage of Nexus