### PR TITLE
Fix atom backward mask for attributed edge removal

### DIFF
--- a/src/gflownet/envs/mol_building_env.py
+++ b/src/gflownet/envs/mol_building_env.py
@@ -326,7 +326,7 @@ class MolBuildingEnvContext(GraphBuildingEnvContext):
 
         remove_edge_mask = np.zeros((len(g.edges), 1), dtype=np.float32)
         for i, e in enumerate(g.edges):
-            if e not in bridges:
+            if e not in bridges and len(g.edges[e]) == 0:
                 remove_edge_mask[i] = 1
 
         edge_attr = np.zeros((len(g.edges) * 2, self.num_edge_dim), dtype=np.float32)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -3,11 +3,19 @@ import pickle
 
 import networkx as nx
 import pytest
+from rdkit.Chem.rdchem import BondType
 
 from gflownet.algo.trajectory_balance import TrajectoryBalance
 from gflownet.config import Config
 from gflownet.envs.frag_mol_env import FragMolBuildingEnvContext
-from gflownet.envs.graph_building_env import ActionIndex, GraphBuildingEnv, GraphBuildingEnvContext
+from gflownet.envs.graph_building_env import (
+    ActionIndex,
+    Graph,
+    GraphAction,
+    GraphActionType,
+    GraphBuildingEnv,
+    GraphBuildingEnvContext,
+)
 from gflownet.envs.mol_building_env import MolBuildingEnvContext
 from gflownet.models import bengio2021flow
 
@@ -175,3 +183,28 @@ def test_backwards_action_mask_equivalence_atom(two_node_states_atoms):
 
 def test_backwards_action_mask_equivalence_ipa_atom(two_node_states_atoms):
     _test_backwards_action_mask_equivalence_ipa(two_node_states_atoms, get_atom_env_ctx())
+
+
+def test_atom_backwards_mask_disallows_removing_attributed_edges():
+    ctx = MolBuildingEnvContext(atoms=["C"], expl_H_range=[0], charges=[0], max_nodes=3)
+    env = GraphBuildingEnv()
+    g = Graph()
+    for i in range(3):
+        g.add_node(i, v="C")
+    g.add_edge(0, 1)
+    g.add_edge(1, 2, type=BondType.DOUBLE)
+    g.add_edge(0, 2)
+
+    gd = ctx.graph_to_Data(g)
+    remove_edge_idx = ctx.GraphAction_to_ActionIndex(
+        gd, GraphAction(GraphActionType.RemoveEdge, source=1, target=2)
+    )
+    remove_edge_attr_idx = ctx.GraphAction_to_ActionIndex(
+        gd, GraphAction(GraphActionType.RemoveEdgeAttr, source=1, target=2, attr="type")
+    )
+
+    assert gd.remove_edge_mask[remove_edge_idx.row_idx, remove_edge_idx.col_idx].item() == 0
+    assert gd.remove_edge_attr_mask[remove_edge_attr_idx.row_idx, remove_edge_attr_idx.col_idx].item() == 1
+    assert env.count_backward_transitions(g, check_idempotent=False) == sum(
+        getattr(gd, action_type.mask_name).sum().item() for action_type in ctx.bck_action_type_order
+    )


### PR DESCRIPTION

## Summary

This PR fixes a mismatch between the atom-level molecular environment's backward
action mask and the parent-counting logic used by the graph-building
environment.

Previously, `MolBuildingEnvContext.graph_to_Data` allowed `RemoveEdge` for any
non-bridge edge. This included edges with bond attributes such as
`type=BondType.DOUBLE`. However, `GraphBuildingEnv.parents()` and
`count_backward_transitions()` only allow direct edge removal when the edge has
no attributes; attributed edges should first remove the edge attribute and only
then remove the plain edge.

## Why this matters

When sampling uniform backward trajectories from QM9 molecules, the old mask
could sample `RemoveEdge` directly on a typed bond. The reverse forward action is
then only `AddEdge`, which does not recreate the original bond attribute. This
can produce inconsistent trajectories where applying the stored forward action
does not recover the stored child graph.

This mainly affects training with uniform backward and results in unstable training.

## Change

- Require direct `RemoveEdge` to be both non-bridge and attribute-free.
- Add a regression test with a three-atom cycle containing one typed bond.
- The test verifies that direct removal of the typed bond is masked out, while
  removing the bond attribute remains allowed, and that the backward mask count
  agrees with `count_backward_transitions`.

## Validation

Locally verified the regression logic with an RDKit-enabled environment:

```text
remove_edge_mask 0.0
remove_edge_attr_mask 1.0
mask_count 3.0
count_backward_transitions 3
```

Also verified on a QM9 backward-sampling diagnostic that the fix removes the
inconsistent attributed-edge transitions:

```text
before: bad_trajs 21 / 256, bad_steps 21 / 3002
after:  bad_trajs 0, bad_steps 0, count_mismatches 0
```

